### PR TITLE
triggerPreRelease: without the title the slack message is malformed

### DIFF
--- a/.github/workflows/trigger_prerelease.yaml
+++ b/.github/workflows/trigger_prerelease.yaml
@@ -76,7 +76,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.bot_token }}"
         run: |
-          gh release create ${{ steps.release-data.outputs.next-version }} --target $(git rev-parse HEAD) --notes-file CHANGELOG.partial.md --prerelease
+          gh release create ${{ steps.release-data.outputs.next-version }} --title ${{ steps.release-data.outputs.next-version }}  --target $(git rev-parse HEAD) --notes-file CHANGELOG.partial.md --prerelease
       - name: Notify failure via Slack
         if: ${{ failure() }}
         uses: archive/github-actions-slack@master


### PR DESCRIPTION
This is useful to avoid this kind of message in slack:
<img width="389" alt="Screenshot 2023-05-30 at 13 44 51" src="https://github.com/newrelic/coreint-automation/assets/43335750/0ce89cb6-9198-4eb3-b1b6-227b404f4c48">
