### PR TITLE
NR-101030: trigger prerelease updates

### DIFF
--- a/.github/workflows/trigger_prerelease.yaml
+++ b/.github/workflows/trigger_prerelease.yaml
@@ -18,6 +18,26 @@ on:
         required: false
         type: string
         default: https://newrelic.github.io/coreint-automation/automatic_release_enable
+      rt-excluded-dirs:
+        description: Release-toolkit excluded-dirs field.
+        required: false
+        type: string
+        default: ""
+      rt-excluded-files:
+        description: Release-toolkit excluded-files field.
+        required: false
+        type: string
+        default: ""
+      rt-included-dirs:
+        description: Release-toolkit included-dirs field.
+        required: false
+        type: string
+        default: ""
+      rt-included-files:
+        description: Release-toolkit included-files field.
+        required: false
+        type: string
+        default: ""
     secrets:
       bot_token:
         description: "github token"
@@ -60,6 +80,11 @@ jobs:
           token: "${{ secrets.bot_token }}"
       - uses: newrelic/release-toolkit/contrib/ohi-release-notes@v1
         id: release-data
+        with:
+          excluded-dirs: "${{ inputs.rt-excluded-dirs }}"
+          excluded-files: "${{ inputs.rt-excluded-files }}"
+          included-dirs: "${{ inputs.rt-included-dirs }}"
+          included-files: "${{ inputs.rt-included-files }}"
       - name: Configure Git
         if: ${{ steps.release-data.outputs.skip-release != 'true' }}
         run: |

--- a/.github/workflows/trigger_prerelease.yaml
+++ b/.github/workflows/trigger_prerelease.yaml
@@ -83,4 +83,4 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
           slack-channel: ${{ secrets.slack_channel }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
+          slack-text: "❌ `${{ github.event.repository.name }}`: prerelease creation failed."

--- a/.github/workflows/trigger_prerelease.yaml
+++ b/.github/workflows/trigger_prerelease.yaml
@@ -108,4 +108,4 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
           slack-channel: ${{ secrets.slack_channel }}
-          slack-text: "❌ `${{ github.event.repository.name }}`: prerelease creation failed."
+          slack-text: "❌ `${{ github.event.repository.full_name }}`: [prerelease trigger failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})"


### PR DESCRIPTION
This PR includes two changes to extend trigger_prerelease reusable workflow:
- It adds support to excluded/included fields of the [release-toolkit/contrib/ohi-release-notes action](https://github.com/newrelic/release-toolkit/tree/main/contrib/ohi-release-notes).
- It fixes the failure message: it includes the repository name from the event and adds a link to the action-run where the job failed.