### PR TITLE
NR-122258: include renovate base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Reusable workflow to pre-release. This is used by ohai repos trigger_prerelease 
         slack_channel: 'slack channel for sending a message in case of failure'
         slack_token: 'slack token for sending the above message'
   ```
-## Automatic releases block endpoint 
+## Automatic releases block endpoint
 
 This repo exposes a github page from the `gh_page` branch containing a file `automatic_release_enable` which is used as a block endpoint.
 Automatic pre-releases executes a GET request to it and fails if the status response is different than 200.
@@ -39,6 +39,32 @@ The block mechanism can be manually set by manually executing the workflow [Bloc
 
 This folder holds several terraform frameworks to deploy integration canary environments. See [Readme](.github/terraform_modules/README.md) for more information.
 
+## Renovate shared config
+
+[renovate-base.json5](./renovate-base.json5) defines a base renovate configuration to be used in all core-int repositories.
+
+ It can be used directly like this:
+
+```json5
+{
+  "extends": [
+    "github>newrelic/coreint-automation:renovate-base.json5"
+  ]
+}
+```
+
+Or include additional rules if needed:
+
+```json5
+ "extends": [
+   "github>newrelic/coreint-automation:renovate-base.json5"
+  ],
+  "packageRules": [
+    // ...
+  ]
+```
+
+Check [Shareable Config Presets in Renovate Docs](https://docs.renovatebot.com/config-presets/#github-actions) for further information.
 
 
 **A note about vulnerabilities**

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Or include additional rules if needed:
 
 Check [Shareable Config Presets in Renovate Docs](https://docs.renovatebot.com/config-presets/#github-actions) for further information.
 
+### Renovate configuration resources
+
+* Renovate logs can be check in [mend developer website](https://developer.mend.io/).
 
 **A note about vulnerabilities**
 

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -15,6 +15,8 @@
       // Only minor and patch versions are auto-merged, major versions will require a PR.
       "matchUpdateTypes": ["minor", "patch"],
       // Exclude packages known for breaking changes even in minor and patch upgrades.
+      // Take into account that this configuration is shared between all integration repos so 
+      // the rule applied here must apply for all of them.
       "excludePackagePatterns": ["sarama"],
       // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
       // according to the SemVer spec.

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -4,6 +4,8 @@
     "config:base"
   ],
   "labels": ["dependencies"],
+  // The rules defined here will be used in all core-int repositories, so they should be valid
+  // for all of them.
   "packageRules": [
     {
       // Enable go indirect dependencies.
@@ -15,8 +17,6 @@
       // Only minor and patch versions are auto-merged, major versions will require a PR.
       "matchUpdateTypes": ["minor", "patch"],
       // Exclude packages known for breaking changes even in minor and patch upgrades.
-      // Take into account that this configuration is shared between all integration repos so 
-      // the rule applied here must apply for all of them.
       "excludePackagePatterns": ["sarama"],
       // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
       // according to the SemVer spec.

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      // Enable go indirect dependencies.
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
+      // Only minor and patch versions are auto-merged, major versions will require a PR.
+      "matchUpdateTypes": ["minor", "patch"],
+      // Exclude packages known for breaking changes even in minor and patch upgrades.
+      "excludePackagePatterns": ["sarama"],
+      // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
+      // according to the SemVer spec.
+      "matchCurrentVersion": "!/^(0|v0)/",
+      // Renovate will do the following when detecting a new dependency bump:
+      // - If it's one of the exclusions it will create a PR (major, 0. or v0. and sarama)
+      // - In case it matches one of the rest cases, it will create a branch that will be auto merged if tests pass.
+      // - If in the previous step tests fail, a PR will be created instead of merging the branch.
+      "automerge": true,
+      "automergeType": "branch",
+      "pruneBranchAfterAutomerge": true
+    },
+    {
+        // golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
+        // Enable golang version bumps but disable auto-merge.
+        "matchDatasources": ["golang-version"],
+        "rangeStrategy": "bump",
+        // The packageRules are overrided/merged, therefore this rule needs to set automerge to false explicitly.
+        "automerge": false,
+    }
+  ]
+}

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -8,12 +8,6 @@
   // for all of them.
   "packageRules": [
     {
-      // Enable go indirect dependencies.
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
-      "enabled": true
-    },
-    {
       // Only minor and patch versions are auto-merged, major versions will require a PR.
       "matchUpdateTypes": ["minor", "patch"],
       // Exclude packages known for breaking changes even in minor and patch upgrades.

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "printConfig": true,
   "labels": ["dependencies"],
   // The rules defined here will be used in all core-int repositories, so they should be valid
   // for all of them.


### PR DESCRIPTION
ℹ️ This includes a base renovate configuration for CoreInt repositories.

🗒️  It can be used directly like this:

```json5
{
  "extends": [
    "github>newrelic/coreint-automation:renovate-base.json5"
  ]
}
```

Or include additional rules if needed:

```json5
 "extends": [
   "github>newrelic/coreint-automation:renovate-base.json5"
  ],
  "packageRules": [
    // ...
  ]
```

🧪 It has been tested in [this nri-postgresql fork](https://github.com/sigilioso/nri-postgresql) using a [temp tag](https://github.com/newrelic/coreint-automation/releases/tag/temp) to be removed once the PR is merged. The corresponding [renovate dashboard issue](https://github.com/sigilioso/nri-postgresql/issues/3) shows that rules are being applied as expected.