### PR TITLE
NR-122258: avoid golang automerge in dockerfile

### DIFF
--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -16,6 +16,8 @@
       // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
       // according to the SemVer spec.
       "matchCurrentVersion": "!/^(0|v0)/",
+      // Exclude golang dependency so golang version in Docker files is not auto-merged.
+      "excludeDepNames": ["golang"],
       // Renovate will do the following when detecting a new dependency bump:
       // - If it's one of the exclusions it will create a PR (major, 0. or v0. and sarama)
       // - In case it matches one of the rest cases, it will create a branch that will be auto merged if tests pass.
@@ -25,12 +27,18 @@
       "pruneBranchAfterAutomerge": true
     },
     {
-        // golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
-        // Enable golang version bumps but disable auto-merge.
+        // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
+        // Enable golang version bumps in 'go.mod' but disable auto-merge.
         "matchDatasources": ["golang-version"],
         "rangeStrategy": "bump",
         // The packageRules are overrided/merged, therefore this rule needs to set automerge to false explicitly.
         "automerge": false,
+    },
+    {
+        // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
+        // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
+        "matchPackageNames": ["golang", "go"],
+        "groupName": "golang version"
     }
   ]
 }


### PR DESCRIPTION
## 📓 Background information

Most core-int repositories rely on the go version defined in go.mod file. Examples:
- [nri-rabbitmq](https://github.com/newrelic/nri-rabbitmq/blob/master/.github/workflows/push_pr.yml#L60)
- [newrelic-prometheus-exporters-packages](https://github.com/newrelic/newrelic-prometheus-exporters-packages/blob/main/.github/workflows/pr.yml#L71)

However, the integration is compiled using the Dockerfile version instead. Example:
- [nri-rabbitmq](https://github.com/newrelic/nri-rabbitmq/blob/master/build/ci.mk#L46)

However, the current renovate configuration doesn't have both dependencies grouped and while go.mod's go version is excluded from auto-merge, but the Dockerfile's go version is not.

## 🔧 Changes

- Exclude the golang dependency from auto-merge settings.
- Group go and golang dependencies together.

## 🧪 Tests

The renovate configuration has been tested in [this fork](https://github.com/sigilioso/nri-postgresql). Now only one branch is created and a PR is opened. 

<img width="700" alt="image" src="https://github.com/newrelic/coreint-automation/assets/442627/90c476d7-67da-4834-8dbe-c59d8911f9de">

<img width="932" alt="image" src="https://github.com/newrelic/coreint-automation/assets/442627/77da5293-b6e7-4e0e-9d87-c828f9b43460">
