### PR TITLE
update sg/ssh key and example template (NR-114593)

### DIFF
--- a/terraform_modules/base_framework/common-network.tf
+++ b/terraform_modules/base_framework/common-network.tf
@@ -132,6 +132,31 @@ resource aws_route_table_association private {
   subnet_id      = aws_subnet.private_subnets[count.index].id
 }
 
+# This security group allows traffic between internal resources and EKS pods
+# All resources deployed on the vpc should have the SG added to allow transparent traffic between them
+# This was done as a workaround
+resource aws_security_group internal_traffic {
+  tags = {
+    Name = "${var.canary_name} Internal Traffic Security Group"
+  }
+  name = "${var.canary_name} Internal Traffic Security Group"
+  vpc_id = aws_vpc.base_vpc.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = -1
+    cidr_blocks = ["${var.network_cidr}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 output common_networking {
   value = {
     aws_vpc = {
@@ -149,6 +174,13 @@ output common_networking {
         arn  = aws_default_security_group.default.arn,
         id   = aws_default_security_group.default.id,
         name = aws_default_security_group.default.name,
+      }
+    }
+    aws_security_group = {
+      internal_traffic = {
+        arn  = aws_security_group.internal_traffic.arn,
+        id   = aws_security_group.internal_traffic.id,
+        name = aws_security_group.internal_traffic.name,
       }
     }
   }

--- a/terraform_modules/base_framework/tls-ca-and-ssh-keys.tf
+++ b/terraform_modules/base_framework/tls-ca-and-ssh-keys.tf
@@ -54,11 +54,16 @@ output tls_ca_and_ssh_keys {
         public_key_pem     = tls_private_key.ssh_client.public_key_pem
       }
     }
+    aws_key_pair = {
+      ssh_key_pair = {
+        key_name = aws_key_pair.ssh_key_pair.key_name
+      }
+    }
   }
 }
 
 
-output sensitive__tls_ca_and_ssh_keys {
+output sensitive_tls_ca_and_ssh_keys {
   sensitive = true
   value = {
     tls_private_key = {

--- a/terraform_modules/canary_template/resource.tf
+++ b/terraform_modules/canary_template/resource.tf
@@ -7,7 +7,8 @@ resource aws_db_subnet_group resource_name {
   name       = "resource_name"
 
   # the following code will retrieve the subnets used by the base vpc so these can be used
-  # to allocate new resources.
+  # to allocate new resources. This is an example, you might want to run only on one of the
+  # subnets or even choose them randomly.
   subnet_ids = [
     data.terraform_remote_state.base_framework.outputs.common_networking.aws_subnet.private_subnets[0].id,
     data.terraform_remote_state.base_framework.outputs.common_networking.aws_subnet.private_subnets[1].id,

--- a/terraform_modules/canary_template/resource.tf
+++ b/terraform_modules/canary_template/resource.tf
@@ -1,16 +1,27 @@
 # This is just an example template on how to fetch resources from the base framework and use
 # them for creating new resources like EC2 instances, Databases, etc...
 #
-# i.e. the following code will retrieve the subnets used by the base vpc so these can be used
-# to allocate new resources
-#
 # DO NOT FORGET to replace "resource_name" with a friendly name of the resource being deployed
 
 resource aws_db_subnet_group resource_name {
   name       = "resource_name"
+
+  # the following code will retrieve the subnets used by the base vpc so these can be used
+  # to allocate new resources.
   subnet_ids = [
     data.terraform_remote_state.base_framework.outputs.common_networking.aws_subnet.private_subnets[0].id,
     data.terraform_remote_state.base_framework.outputs.common_networking.aws_subnet.private_subnets[1].id,
     data.terraform_remote_state.base_framework.outputs.common_networking.aws_subnet.private_subnets[2].id,
   ]
+
+  # the following code will retrieve the security groups that should be assigned to a new resource
+  # allowing it to be accessible from all other resources within the main vpc.
+  vpc_security_group_ids      = [
+    data.terraform_remote_state.base_framework.outputs.common_networking.aws_default_security_group.default.id,
+    data.terraform_remote_state.base_framework.outputs.common_networking.aws_security_group.internal_traffic.id
+  ]
+
+  # the following code will retrieve the canary ssh key name that can be assigned to an EC2 instance
+  # to allow access to it.
+  key_name = data.terraform_remote_state.base_framework.outputs.tls_ca_and_ssh_keys.aws_key_pair.ssh_key_pair.key_name
 }


### PR DESCRIPTION
* Updates common network to include a SG that allows traffic between resources in the vpc (This is implemented to workaround communication between EKS pods and internal resources)
* Outputs the SSSh key name to be easily imported by new resources
* Updates template example