### PR TITLE
Revert actions using hash instead of tag

### DIFF
--- a/.github/workflows/block.yaml
+++ b/.github/workflows/block.yaml
@@ -15,7 +15,7 @@ jobs:
       # Allows github.token to push commit
       contents: write
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
       - name: remove unblock file

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,7 +22,7 @@ jobs:
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/reposettings.yaml
+++ b/.github/workflows/reposettings.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Apply GH repo settings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Read reposettings.yml
         run: |
           echo 'REPOSETTINGS_YML<<EOF' >> $GITHUB_ENV

--- a/.github/workflows/trigger_prerelease.yaml
+++ b/.github/workflows/trigger_prerelease.yaml
@@ -83,7 +83,7 @@ jobs:
             echo This workflow should only be triggered for the '${{ github.event.repository.default_branch }}' branch
             exit 1
           fi
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/unblock.yaml
+++ b/.github/workflows/unblock.yaml
@@ -15,7 +15,7 @@ jobs:
       # Allows github.token to push commit
       contents: write
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
       - name: Create unblock file


### PR DESCRIPTION
I misread the PRs from renovate and merged PRs that changed the tag to a commit hash.

We don't know if renovate will update commits written like that and if renovate might stick to master instead of following tag conventions.

As this is an untested territory I prefer to revert the change and keep working with tags.