### PR TITLE
[chore] Rename pipelines and centralise the security ones

### DIFF
--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -1,0 +1,24 @@
+name: Push/PR pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - renovate/**
+  pull_request:
+
+jobs:
+  renovate-config-validator:
+    name: Renovatebot config validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Renovatebot config validator
+        run: npm install --global renovate
+
+      - name: Test that the config is valid
+        run: |
+            find -name renovate\*.json\* -exec renovate-config-validator {} \; || renovate-config-validator

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -2,30 +2,11 @@
 # workflow_dispatch to work properly
 name: Repolinter Action
 
-# NOTE: This workflow will ONLY check the default branch!
-# Currently there is no elegant way to specify the default
-# branch in the event filtering, so branches are instead
-# filtered in the "Test Default Branch" step.
-on: [push, workflow_dispatch]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
-  repolint:
-    name: Run Repolinter
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test Default Branch
-        id: default-branch
-        uses: actions/github-script@v2
-        with:
-          script: |
-            const data = await github.repos.get(context.repo)
-            return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
-      - name: Checkout Self
-        if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v4
-      - name: Run Repolinter
-        if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: newrelic/repolinter-action@v1
-        with:
-          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-project.yml
-          output_type: issue
+  repolinter:
+    uses: ./.github/workflows/reusable_repolinter.yaml@v1
+  # uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v1

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   repolinter:
-    uses: ./.github/workflows/reusable_repolinter.yaml@v1
+    uses: ./.github/workflows/reusable_repolinter.yaml
   # uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v1

--- a/.github/workflows/reusable_repolinter.yaml
+++ b/.github/workflows/reusable_repolinter.yaml
@@ -3,7 +3,7 @@ name: Repolinter Action
 # To see how to reuse this workflow, see `repolinter.yml` workflow in this repository.
 
 on:
-  workflow_dispatch:
+  workflow_call:
 
 # NOTE: This workflow will ONLY check the default branch!
 # Currently there is no elegant way to specify the default

--- a/.github/workflows/reusable_repolinter.yaml
+++ b/.github/workflows/reusable_repolinter.yaml
@@ -1,0 +1,32 @@
+name: Repolinter Action
+
+# To see how to reuse this workflow, see `repolinter.yml` workflow in this repository.
+
+on:
+  workflow_dispatch:
+
+# NOTE: This workflow will ONLY check the default branch!
+# Currently there is no elegant way to specify the default
+# branch in the event filtering, so branches are instead
+# filtered in the "Test Default Branch" step.
+jobs:
+  repolint:
+    name: Run Repolinter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Default Branch
+        id: default-branch
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const data = await github.repos.get(context.repo)
+            return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
+      - name: Checkout Self
+        if: ${{ steps.default-branch.outputs.result == 'true' }}
+        uses: actions/checkout@v4
+      - name: Run Repolinter
+        if: ${{ steps.default-branch.outputs.result == 'true' }}
+        uses: newrelic/repolinter-action@v1
+        with:
+          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-project.yml
+          output_type: issue

--- a/.github/workflows/reusable_security.yaml
+++ b/.github/workflows/reusable_security.yaml
@@ -1,0 +1,53 @@
+name: Security Scan
+
+# To see how to reuse this workflow, see `security.yaml` workflow in this repository.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-dirs:
+        description: 'comma separated list of directories where traversal is skipped'
+        required: false
+        default: ''
+      skip-files:
+        description: 'comma separated list of files to be skipped'
+        required: false
+        default: ''
+
+jobs:
+  trivy:
+    name: Trivy security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.12.0
+        if: ${{ ! github.event.schedule }}  # Do not run inline checks when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: "${{ inputs.skip-dirs }}"
+          skip-files: "${{ inputs.skip-files }}"
+
+      - name: Run Trivy vulnerability scanner sarif output
+        uses: aquasecurity/trivy-action@0.12.0
+        if: ${{ github.event.schedule }}  # Generate sarif when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          skip-dirs: "${{ inputs.skip-dirs }}"
+          skip-files: "${{ inputs.skip-files }}"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ github.event.schedule }}  # Upload sarif when running periodically
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/reusable_security.yaml
+++ b/.github/workflows/reusable_security.yaml
@@ -3,15 +3,17 @@ name: Security Scan
 # To see how to reuse this workflow, see `security.yaml` workflow in this repository.
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       skip-dirs:
         description: 'comma separated list of directories where traversal is skipped'
         required: false
+        type: string
         default: ''
       skip-files:
         description: 'comma separated list of files to be skipped'
         required: false
+        type: string
         default: ''
 
 jobs:

--- a/.github/workflows/reusable_trigger_prerelease.yaml
+++ b/.github/workflows/reusable_trigger_prerelease.yaml
@@ -9,6 +9,8 @@ name: Trigger pre-release shared workflow
 #        bot_token: {{ secret."github_token_name" }}
 #        slack_channel: {{ secret."slack_channel_name" }}
 #        slack_token: {{ secret."slack_token_name" }}
+#      with:
+#        rt-included-files: go.mod,go.sum,build/Dockerfile
 
 on:
   workflow_call:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,19 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - renovate/**
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  security:
+  # uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v1
+    uses: ./.github/workflows/reusable_security.yaml@v1
+  # with:
+  #   skip-dirs: "build"
+  #   skip-files: "some-testing-tls-file"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   security:
   # uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v1
-    uses: ./.github/workflows/reusable_security.yaml@v1
+    uses: ./.github/workflows/reusable_security.yaml
   # with:
   #   skip-dirs: "build"
   #   skip-files: "some-testing-tls-file"

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
As the first iteration to standardize the pipelines, I need all the pipelines to be named the same way

I'll need to run scripts to analyze them such as `diff` and `yq` to see the differences between them and having them with different names makes the scripts a mess.

This is the bare minimum start even if the effort to standardize the pipelines finally does not happen.

This PR also renames the reusable pipelines with the prefix `reusable_` so we can have more readable pipelines as this repository is expected to grow a lot in the near future.