### PR TITLE
NR-211968: Add push pr reusable workflows

### DIFF
--- a/.github/workflows/_static_analysis.yaml
+++ b/.github/workflows/_static_analysis.yaml
@@ -1,0 +1,18 @@
+name: Static Analysis
+
+on:
+  workflow_call:
+
+jobs:
+  static-analysis:
+    name: Run all static analysis checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: newrelic/newrelic-infra-checkers@v1
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          only-new-issues: true
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1

--- a/.github/workflows/_test_build_fake_prerelease.yaml
+++ b/.github/workflows/_test_build_fake_prerelease.yaml
@@ -1,0 +1,84 @@
+name: Test Build Fake Prerelease
+
+on:
+  workflow_call:
+    inputs:
+      integration:
+        required: true
+        type: string
+    secrets:
+      OHAI_PFX_CERTIFICATE_BASE64:
+        required: true
+      OHAI_PFX_PASSPHRASE:
+        required: true
+
+jobs:
+  test-build-nix:
+    name: Test binary compilation for all platforms:arch
+    runs-on: ubuntu-20.04
+    env:
+      INTEGRATION: ${{ inputs.integration }}
+      REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+      TAG: "v0.0.0"
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
+      - name: Build all platforms:arch
+        run: make ci/fake-prerelease
+      - name: Upload artifacts for next job
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-packages
+          path: dist/nri-*.zip
+
+  test-build-windows:
+    name: Create MSI
+    runs-on: windows-latest
+    needs: [test-build-nix]
+    env:
+      INTEGRATION: ${{ inputs.integration }}
+      REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+      TAG: "v0.0.0"
+      GOPATH: ${{ github.workspace }}
+      PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
+      PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
+      PFX_PASSPHRASE: ${{ secrets.OHAI_PFX_PASSPHRASE }}
+    defaults:
+      run:
+        working-directory: src/github.com/${{ github.event.repository.full_name }}
+    strategy:
+      matrix:
+        goarch: [ amd64,386 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: src/github.com/${{ github.event.repository.full_name }}
+      - shell: bash
+        run: git tag "$TAG"
+
+      - name: Download artifact from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-packages
+          path: src/github.com/${{ github.event.repository.full_name }}/dist/
+
+      - name: Get PFX certificate from GH secrets
+        shell: bash
+        run: |
+          if [ -z "$PFX_CERTIFICATE_BASE64" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          else
+            printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+          fi
+
+      - name: Extract .exe
+        shell: pwsh
+        run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+      - name: Create MSI
+        shell: pwsh
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/.github/workflows/_test_build_nix.yaml
+++ b/.github/workflows/_test_build_nix.yaml
@@ -1,0 +1,15 @@
+name: Test Build *Nix
+
+on:
+  workflow_call:
+
+jobs:
+  test-build-nix:
+    name: Test binary compilation for all platforms:arch
+    runs-on: ubuntu-latest
+    env:
+      TAG: "v0.0.0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build all platforms:arch
+        run: make ci/build

--- a/.github/workflows/_test_integration_nix.yaml
+++ b/.github/workflows/_test_integration_nix.yaml
@@ -1,0 +1,18 @@
+name: Integration Tests on *Nix
+
+on:
+  workflow_call:
+
+jobs:
+  test-integration-nix:
+    name: Run integration tests on *Nix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Integration test
+        run: make integration-test

--- a/.github/workflows/_test_nix.yaml
+++ b/.github/workflows/_test_nix.yaml
@@ -1,0 +1,13 @@
+name: Unit Tests on *Nix
+
+on:
+  workflow_call:
+
+jobs:
+  test-nix:
+    name: Run unit tests on *Nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Unit tests
+        run: make ci/test

--- a/.github/workflows/_test_windows.yaml
+++ b/.github/workflows/_test_windows.yaml
@@ -1,0 +1,20 @@
+name: Unit Tests on Windows
+
+on:
+  workflow_call:
+
+jobs:
+  test-windows:
+    name: Run unit tests on Windows
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Running unit tests
+        shell: pwsh
+        run: |
+          .\build\windows\unit_tests.ps1

--- a/.github/workflows/reusable_push_pr.yaml
+++ b/.github/workflows/reusable_push_pr.yaml
@@ -1,0 +1,60 @@
+name: Push/PR shared workflow
+
+# This workflow integrates both the standard test workflow for pull requests and the process
+# of testing packages creation.
+
+on:
+  workflow_call:
+    inputs:
+      integration:
+        required: false
+        type: string
+      run_test_windows:
+        required: false
+        type: boolean
+        default: true
+      run_integration_nix:
+        required: false
+        type: boolean
+        default: true
+      run_test_build_nix:
+        required: false
+        type: boolean
+        default: true
+      run_test_build_fake_prerelease:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      OHAI_PFX_CERTIFICATE_BASE64:
+        required: false
+      OHAI_PFX_PASSPHRASE:
+        required: false
+
+jobs:
+  static-analysis:
+    uses: ./.github/workflows/_static_analysis.yaml
+
+  test-nix:
+    uses: ./.github/workflows/_test_nix.yaml
+
+  test-windows:
+    if: ${{ inputs.run_test_windows }}
+    uses: ./.github/workflows/_test_windows.yaml
+
+  test-integration-nix:
+    if: ${{ inputs.run_integration_nix }}
+    uses: ./.github/workflows/_test_integration_nix.yaml
+
+  test-build-nix:
+    if: ${{ inputs.run_test_build_nix }}
+    uses: ./.github/workflows/_test_build_nix.yaml
+
+  test-build-fake-prerelease:
+    if: ${{ inputs.run_test_build_fake_prerelease }}
+    uses: ./.github/workflows/_test_build_fake_prerelease.yaml
+    secrets:
+      OHAI_PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }}
+      OHAI_PFX_PASSPHRASE: ${{ secrets.OHAI_PFX_PASSPHRASE }}
+    with:
+      integration: ${{ inputs.integration }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Reusable workflow to pre-release. This is used by ohai repos trigger_prerelease 
         slack_channel: 'slack channel for sending a message in case of failure'
         slack_token: 'slack token for sending the above message'
   ```
+### push_pr
+
+Reusable workflow that combines the standard testing process for pull requests with the testing of package creation.
+
+Usage:
+```
+jobs:
+  push-pr:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_push_pr.yaml@v1
+    secrets: inherit
+    with:
+      run_test_build_nix: false
+      run_test_build_fake_prerelease: true
+      integration: 'integration name'
+```
+
 
 ### on_release
 


### PR DESCRIPTION
This PR adds a Push PR reusable workflows composed of several other pluggable single workflows.

These workflows have been tested in the following PRs:
- https://github.com/newrelic/nri-redis/pull/182
- https://github.com/newrelic/nri-apache/pull/114
- https://github.com/newrelic/nri-oracledb/pull/155

**Note:** To test the fake prereleases flow (such as the 2nd PR) I've used a `worflow_run` approach in order to run the `Test Build Windows` workflow once the previous needed `Test Build Nix fake prerelease` workflows is completed. From GitHub notes, we are not going to be able to test this until this **workflow is merged in the default branch.**

More details here https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
> Note: This event will only trigger a workflow run if the workflow file is on the default branch.