### PR TITLE
Fix linting errors

### DIFF
--- a/.github/workflows/_static_analysis.yaml
+++ b/.github/workflows/_static_analysis.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: newrelic/newrelic-infra-checkers@v1
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
       - name: Check if CHANGELOG is valid


### PR DESCRIPTION
We need to reintroduce the `continue-on-error` flag with the condition `github.event_name != 'pull_request'` to prevent workflow failures when merging changes into the master branch, such as the one encountered in this [example](https://github.com/newrelic/nri-redis/actions/runs/7740601084/job/21105883286).

The reason for this is that golangci-lint behaves differently when run in different contexts:


1. When run in a merge  context:
- In this mode, golangci-lint performs linting on the entire codebase without taking into account the changes being merged.
- Example command: `/home/runner/golangci-lint-1.55.2-linux-amd64/golangci-lint run --out-format=github-actions`

2. When run from a pull request (PR) context:
- In this mode, golangci-lint analyzes and lints only the changes made in the PR, ensuring that it checks the modified code by applying a patch.
- Example command: `/home/runner/golangci-lint-1.55.2-linux-amd64/golangci-lint run --out-format=github-actions --new-from-patch=/tmp/tmp.patch --new=false`