### PR TITLE
fix: install go for static analysis

### DIFF
--- a/.github/workflows/_static_analysis.yaml
+++ b/.github/workflows/_static_analysis.yaml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: newrelic/newrelic-infra-checkers@v1
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         continue-on-error: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
golangci-lint is failing with:

```
level=error msg="Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: go: errors parsing go.mod:\n/home/runner/work/nri-apache/nri-apache/go.mod:3: invalid go version '1.21.6': must match format 1.23\n"
```

when loading some of the linters we have configured due to outdated go version in the runner. 
Seems to be related with this https://github.com/golang/go/issues/61888