### PR TITLE
[reusable workflows] required fake-prerelease fields for nrjmx based integrations

### DIFF
--- a/.github/workflows/_test_build_fake_prerelease.yaml
+++ b/.github/workflows/_test_build_fake_prerelease.yaml
@@ -9,6 +9,10 @@ on:
       goarch_matrix:
         required: true
         type: string
+      download_nrjmx:
+        required: false
+        type: boolean
+        default: false
     secrets:
       OHAI_PFX_CERTIFICATE_BASE64:
         required: true
@@ -82,6 +86,12 @@ jobs:
       - name: Extract .exe
         shell: pwsh
         run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+
+      - name: Download nrjmx
+        if: ${{ inputs.download_nrjmx }}
+        shell: bash
+        run: build/windows/download_nrjmx.sh
+
       - name: Create MSI
         shell: pwsh
         run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/.github/workflows/_test_build_fake_prerelease.yaml
+++ b/.github/workflows/_test_build_fake_prerelease.yaml
@@ -6,6 +6,9 @@ on:
       integration:
         required: true
         type: string
+      goarch_matrix:
+        required: true
+        type: string
     secrets:
       OHAI_PFX_CERTIFICATE_BASE64:
         required: true
@@ -52,7 +55,7 @@ jobs:
         working-directory: src/github.com/${{ github.event.repository.full_name }}
     strategy:
       matrix:
-        goarch: [ amd64,386 ]
+        goarch: ${{ fromJSON(inputs.goarch_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_push_pr.yaml
+++ b/.github/workflows/reusable_push_pr.yaml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: false
+      fake_prerelease_goarch_matrix:
+        required: false
+        type: string
+        default: '["amd64", "386"]'
     secrets:
       OHAI_PFX_CERTIFICATE_BASE64:
         required: false
@@ -58,3 +62,4 @@ jobs:
       OHAI_PFX_PASSPHRASE: ${{ secrets.OHAI_PFX_PASSPHRASE }}
     with:
       integration: ${{ inputs.integration }}
+      goarch_matrix: ${{ inputs.fake_prerelease_goarch_matrix }}

--- a/.github/workflows/reusable_push_pr.yaml
+++ b/.github/workflows/reusable_push_pr.yaml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: '["amd64", "386"]'
+      fake_prerelease_download_nrjmx:
+        required: false
+        type: boolean
+        default: false
     secrets:
       OHAI_PFX_CERTIFICATE_BASE64:
         required: false
@@ -63,3 +67,4 @@ jobs:
     with:
       integration: ${{ inputs.integration }}
       goarch_matrix: ${{ inputs.fake_prerelease_goarch_matrix }}
+      download_nrjmx: ${{ inputs.fake_prerelease_download_nrjmx }}


### PR DESCRIPTION
This PR introduces to new fields in the `reusable_push_pr` workflow:

- `fake_prerelease_goarch_matrix`
- `fake_prerelease_download_nrjmx` 

These fields are needed in nrjmx based integrations. 

Tested in nri-cassandra: newrelic/nri-cassandra#181

### TODO
- Move `v2` tag after merging it.