### PR TITLE
feat: update pre-relase reusable workflow to support nrjmx based integrations

### DIFF
--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -44,12 +44,12 @@ on:
         default: msi
         required: false
         type: string
-      goarch_matrix:
+      windows_goarch_matrix:
         description: "Defines a custom goarch-matrix for windows builds as nrjmx based integrations support amd64 only (it needs to be a JSON array)"
         required: false
         type: string
         default: '["amd64", "386"]'
-      download_nrjmx:
+      windows_download_nrjmx:
         description: "When enabled, the windows build will download nrjmx"
         required: false
         type: boolean
@@ -126,7 +126,7 @@ jobs:
     needs: [build-artifacts]
     strategy:
       matrix:
-        goarch: ${{ fromJSON(inputs.goarch_matrix) }}
+        goarch: ${{ fromJSON(inputs.windows_goarch_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
         run: |
           build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
       - name: Download nrjmx
-        if: ${{ inputs.download_nrjmx }}
+        if: ${{ inputs.windows_download_nrjmx }}
         shell: bash
         run: build/windows/download_nrjmx.sh
       - name: Create MSI

--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -45,7 +45,7 @@ on:
         required: false
         type: string
       goarch_matrix:
-        description: "Defines a custom goarch-matrix for windows builds as nrjmx based integrations support amd64 only"
+        description: "Defines a custom goarch-matrix for windows builds as nrjmx based integrations support amd64 only (it needs to be a JSON array)"
         required: false
         type: string
         default: '["amd64", "386"]'

--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -44,6 +44,17 @@ on:
         default: msi
         required: false
         type: string
+      goarch_matrix:
+        description: "Defines a custom goarch-matrix for windows builds as nrjmx based integrations support amd64 only"
+        required: false
+        type: string
+        default: '["amd64", "386"]'
+      download_nrjmx:
+        description: "When enabled, the windows build will download nrjmx"
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       OHAI_AWS_ROLE_ARN_STAGING:
         required: true
@@ -115,7 +126,7 @@ jobs:
     needs: [build-artifacts]
     strategy:
       matrix:
-        goarch: [amd64,386]
+        goarch: ${{ fromJSON(inputs.goarch_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,6 +139,10 @@ jobs:
         shell: pwsh
         run: |
           build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+      - name: Download nrjmx
+        if: ${{ inputs.download_nrjmx }}
+        shell: bash
+        run: build/windows/download_nrjmx.sh
       - name: Create MSI
         shell: pwsh
         env:
@@ -202,4 +217,3 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
           slack-text: "❌ `${{ github.event.repository.full_name }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})."
-


### PR DESCRIPTION
Introduce the parameters required for nrjmx based integrations in the reusable pre-release workflow (in the same way it was done for push/pr fake-prerelease #51)