### PR TITLE
Add helper scripts for hero duties (NR-249369)

### DIFF
--- a/tools/common-functions.sh
+++ b/tools/common-functions.sh
@@ -1,0 +1,50 @@
+# This file must be used with "source common.sh". You cannot run it directly
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script: \$ source $0" >&2
+    exit 1
+fi
+
+ORG="newrelic";
+# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+# gh api /orgs/newrelic/teams/coreint | jq .id
+TEAM_ID="3626876";
+
+reference_status () {
+    REPOSITORY_SLUG="$1"
+    REFERENCE="$2"
+
+    # Get all statuses of a reference
+    # Ref: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28
+    # Save you a click:
+    #  'status': queued, in_progress, completed
+    #  'conclusion': action_required, cancelled, failure, neutral, success, skipped, stale, timed_out 
+    STATUSES=$(gh api "/repos/${REPOSITORY_SLUG}/commits/${REFERENCE}/check-runs" \
+        --jq '.check_runs[] | .status + ";" + .conclusion + ";" + .name + ";" + .html_url'
+    )
+    #outputs something like:
+    # completed;success;security / Trivy security scan;https://github.com/newrelic/nri-mssql/actions/runs/8090423977/job/22107883691
+    # completed;skipped;prerelease / Create prerelease;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022509783
+    # completed;failure;prerelease / Check block endpoint;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022501960
+    if [ -z "${STATUSES}" ]; then
+        # $STATUSES can be empty if no is has no runs
+        # It is a corner case on legacy repos: nri-snmp and nri-zookeeper
+        return
+    fi
+    # Test if it has a job running at the moment.
+    if cut -d\; -f1 <<<"${STATUSES}" | grep -E "in_progress" > /dev/null 2>&1; then
+        echo "⚠️ The repository ${REPOSITORY_SLUG} has a job in progress in the reference ${REPOSITORY_SLUG}. Skipping status checks."
+        continue
+    fi
+    # Test if any run failed.
+    if cut -d\; -f2 <<<"${STATUSES}" | grep -E "(failure|neutral|stale|timed_out)" > /dev/null 2>&1; then
+        # A run failed. Pretty printing to make them human readable.
+        echo "A failing or inconsistent job has been found in '${REFERENCE}' at ${REPOSITORY_SLUG}:"
+        echo "============================================================================="
+        while IFS=';' read STATUS CONCLUSION JOB_NAME URL; do
+            if grep -E "(failure|neutral|stale|timed_out)" <<<"${CONCLUSION}" > /dev/null 2>&1; then
+                printf "‼️ %s on %s URL: %s\n" "${CONCLUSION}" "${JOB_NAME}" "${URL}" 
+            fi
+        done <<<"${STATUSES}"
+        echo
+    fi
+}

--- a/tools/list-failed-releases.sh
+++ b/tools/list-failed-releases.sh
@@ -2,10 +2,7 @@
 
 set -euo pipefail
 
-ORG="newrelic";
-# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
-# gh api /orgs/newrelic/teams/coreint | jq .id
-TEAM_ID="3626876";
+source "$(dirname $(readlink -f $0))/common-functions.sh"
 
 # Listing all repositories that start with `nri-` that belongs to coreint
 gh api --paginate "/teams/${TEAM_ID}/repos" --jq '.[] | select(.name | startswith("nri-")) | .name' | \
@@ -17,38 +14,5 @@ while read REPO_NAME; do
         '
     )
 
-    # Get all statuses of the tag
-    # Ref: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28
-    # Save you a click:
-    #  'status': queued, in_progress, completed
-    #  'conclusion': action_required, cancelled, failure, neutral, success, skipped, stale, timed_out 
-    STATUSES=$(gh api "/repos/${ORG}/${REPO_NAME}/commits/${LATEST_TAG}/check-runs" \
-        --jq '.check_runs[] | .status + ";" + .conclusion + ";" + .name + ";" + .html_url'
-    )
-    #outputs something like:
-    # completed;success;security / Trivy security scan;https://github.com/newrelic/nri-mssql/actions/runs/8090423977/job/22107883691
-    # completed;skipped;prerelease / Create prerelease;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022509783
-    # completed;failure;prerelease / Check block endpoint;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022501960
-    if [ -z "${STATUSES}" ]; then
-        # $STATUSES can be empty if no is has no runs
-        # It is a corner case on legacy repos: nri-snmp and nri-zookeeper
-        continue
-    fi
-    # Test if it has a job running at the moment.
-    if cut -d\; -f1 <<<"${STATUSES}" | grep -E "in_progress" > /dev/null 2>&1; then
-        echo "⚠️ The repository ${REPO_NAME} has a job in progress. Skipping status checks."
-        continue
-    fi
-    # Test if any run failed.
-    if cut -d\; -f2 <<<"${STATUSES}" | grep -E "(failure|neutral|stale|timed_out)" > /dev/null 2>&1; then
-        # A run failed. Pretty printing to make them human readable.
-        echo "A failing or inconsistent job has been found in the integration ${REPO_NAME}:"
-        echo "============================================================================="
-        while IFS=';' read STATUS CONCLUSION JOB_NAME URL; do
-            if grep -E "(failure|neutral|stale|timed_out)" <<<"${CONCLUSION}" > /dev/null 2>&1; then
-                printf "‼️ %s on %s URL: %s\n" "${CONCLUSION}" "${JOB_NAME}" "${URL}" 
-            fi
-        done <<<"${STATUSES}"
-        echo
-    fi
+    reference_status "${ORG}/${REPO_NAME}" "${LATEST_TAG}"
 done

--- a/tools/list-failed-releases.sh
+++ b/tools/list-failed-releases.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORG="newrelic";
+# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+# gh api /orgs/newrelic/teams/coreint | jq .id
+TEAM_ID="3626876";
+
+# Listing all repositories that start with `nri-` that belongs to coreint
+gh api --paginate "/teams/${TEAM_ID}/repos" --jq '.[] | select(.name | startswith("nri-")) | .name' | \
+while read REPO_NAME; do
+    # Get the date of the latest release.
+    LATEST_TAG=$(
+        gh release list --json publishedAt,isLatest,tagName -R "${ORG}/${REPO_NAME}" --jq '
+            .[] | select(.isLatest) | .tagName
+        '
+    )
+
+    # Get all statuses of the tag
+    # Ref: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28
+    # Save you a click:
+    #  'status': queued, in_progress, completed
+    #  'conclusion': action_required, cancelled, failure, neutral, success, skipped, stale, timed_out 
+    STATUSES=$(gh api "/repos/${ORG}/${REPO_NAME}/commits/${LATEST_TAG}/check-runs" \
+        --jq '.check_runs[] | .status + ";" + .conclusion + ";" + .name + ";" + .html_url'
+    )
+    #outputs something like:
+    # completed;success;security / Trivy security scan;https://github.com/newrelic/nri-mssql/actions/runs/8090423977/job/22107883691
+    # completed;skipped;prerelease / Create prerelease;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022509783
+    # completed;failure;prerelease / Check block endpoint;https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022501960
+    if [ -z "${STATUSES}" ]; then
+        # $STATUSES can be empty if no is has no runs
+        # It is a corner case on legacy repos: nri-snmp and nri-zookeeper
+        continue
+    fi
+    # Test if it has a job running at the moment.
+    if cut -d\; -f1 <<<"${STATUSES}" | grep -E "in_progress" > /dev/null 2>&1; then
+        echo "⚠️ The repository ${REPO_NAME} has a job in progress. Skipping status checks."
+        continue
+    fi
+    # Test if any run failed.
+    if cut -d\; -f2 <<<"${STATUSES}" | grep -E "(failure|neutral|stale|timed_out)" > /dev/null 2>&1; then
+        # A run failed. Pretty printing to make them human readable.
+        echo "A failing or inconsistent job has been found in the integration ${REPO_NAME}:"
+        echo "============================================================================="
+        while IFS=';' read STATUS CONCLUSION JOB_NAME URL; do
+            if grep -E "(failure|neutral|stale|timed_out)" <<<"${CONCLUSION}" > /dev/null 2>&1; then
+                printf "‼️ %s on %s URL: %s\n" "${CONCLUSION}" "${JOB_NAME}" "${URL}" 
+            fi
+        done <<<"${STATUSES}"
+        echo
+    fi
+done

--- a/tools/list-not-released-prereleases.sh
+++ b/tools/list-not-released-prereleases.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORG="newrelic";
+# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
+# gh api /orgs/newrelic/teams/coreint | jq .id
+TEAM_ID="3626876";
+
+# Listing all repositories that start with `nri-` that belongs to coreint
+gh api --paginate "/teams/${TEAM_ID}/repos" --jq '.[] | select(.name | startswith("nri-")) | .name' | \
+while read REPO_NAME; do
+    # Get the date of the latest release.
+    LATEST_RELEASE=$(
+        gh release list --json publishedAt,isLatest -R "${ORG}/${REPO_NAME}" --jq '
+            .[] | select(.isLatest) | .publishedAt | fromdateiso8601
+        '
+    )
+
+    # List all releases, filter by prereleases that was made later than the latest release, sort by date,
+    # reverse because the last one is the most recent and only grab the last prerelease
+    NON_PUBLISHED_PRERELEASES=$(
+        gh release list --json name,publishedAt,isPrerelease,isLatest,tagName -R "${ORG}/${REPO_NAME}" --jq '
+            [
+                .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE}'))
+            ]
+            | sort_by(.publishedAt |= fromdateiso8601) | reverse | first
+        '
+    )
+    if ! [ -z "${NON_PUBLISHED_PRERELEASES}" ]; then
+        # Next querie uses the list release API endpoint:
+        # https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+
+        # gh list release is limited only to fields createdAt, isDraft, isLatest, isPrerelease, name, publishedAt, and tagName
+        # We need the URL to show it to the user.
+
+        NAME=$(jq -r .name <<<"${NON_PUBLISHED_PRERELEASES}") # Name of the release
+        TAG=$(jq -r .tagName <<<"${NON_PUBLISHED_PRERELEASES}") # Tag of the release
+        URL=$(gh api --paginate "/repos/${ORG}/${REPO_NAME}/releases/tags/${TAG}" --jq '.html_url') # URL of the release
+
+        echo " > Prerelease found for ${REPO_NAME}: ${URL}"
+        echo "# gh release edit -R \"${ORG}/${REPO_NAME}\" \"$NAME\" --prerelease=false --latest"
+    fi
+done

--- a/tools/list-not-released-prereleases.sh
+++ b/tools/list-not-released-prereleases.sh
@@ -2,10 +2,7 @@
 
 set -euo pipefail
 
-ORG="newrelic";
-# https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
-# gh api /orgs/newrelic/teams/coreint | jq .id
-TEAM_ID="3626876";
+source "$(dirname $(readlink -f $0))/common-functions.sh"
 
 # Listing all repositories that start with `nri-` that belongs to coreint
 gh api --paginate "/teams/${TEAM_ID}/repos" --jq '.[] | select(.name | startswith("nri-")) | .name' | \
@@ -38,7 +35,9 @@ while read REPO_NAME; do
         TAG=$(jq -r .tagName <<<"${NON_PUBLISHED_PRERELEASES}") # Tag of the release
         URL=$(gh api --paginate "/repos/${ORG}/${REPO_NAME}/releases/tags/${TAG}" --jq '.html_url') # URL of the release
 
-        echo " > Prerelease found for ${REPO_NAME}: ${URL}"
-        echo "# gh release edit -R \"${ORG}/${REPO_NAME}\" \"$NAME\" --prerelease=false --latest"
+        echo "  >>>  Prerelease found for ${REPO_NAME}: ${URL}"
+        echo "       You can release it by running: \`gh release edit -R \"${ORG}/${REPO_NAME}\" \"$NAME\" --prerelease=false --latest'"
+        echo
+        reference_status "${ORG}/${REPO_NAME}" "${TAG}"
     fi
 done


### PR DESCRIPTION
I have added two scripts that allows us to see which prereleases have not been released yet and which releases have a failed to release properly.

### EDIT

After [the comment that @sigilioso left](https://github.com/newrelic/coreint-automation/pull/59#discussion_r1549071739), I moved the constants and the logic to see if a commit has all check runs consistently finished to a common file.

While testing the scripts, I suffered reading the output problems, so I changed it a bit. Now running the scripts should look like this:
`./tools/list-not-released-prereleases.sh`
```
  >>>  Prerelease found for nri-kafka: https://github.com/newrelic/nri-kafka/releases/tag/v3.7.2
       You can release it by running: `gh release edit -R "newrelic/nri-kafka" "v3.7.2" --prerelease=false --latest'

  >>>  Prerelease found for nri-mongodb: https://github.com/newrelic/nri-mongodb/releases/tag/v2.8.3
       You can release it by running: `gh release edit -R "newrelic/nri-mongodb" "v2.8.3" --prerelease=false --latest'

A failing or inconsistent job has been found in 'v2.8.3' at newrelic/nri-mongodb:
=============================================================================
‼️ failure on Analyze (go) URL: https://github.com/newrelic/newrelic/nri-mongodb/actions/runs/8243483162/job/22544154212
‼️ failure on Analyze (go) URL: https://github.com/newrelic/newrelic/nri-mongodb/actions/runs/8170681145/job/22337297368

  >>>  Prerelease found for nri-couchbase: https://github.com/newrelic/nri-couchbase/releases/tag/v2.6.3
       You can release it by running: `gh release edit -R "newrelic/nri-couchbase" "v2.6.3" --prerelease=false --latest'

```
`./tools/list-failed-releases.sh`
```
A failing or inconsistent job has been found in 'v3.6.0' at newrelic/nri-jmx:
=============================================================================
‼️ failure on Analyze (go) URL: https://github.com/newrelic/nri-jmx/actions/runs/8243483162/job/22544154212
‼️ failure on Analyze (go) URL: https://github.com/newrelic/nri-jmx/actions/runs/8170681145/job/22337297368

A failing or inconsistent job has been found in 'v2.12.0' at newrelic/nri-mssql:
=============================================================================
‼️ failure on prerelease / Check block endpoint URL: https://github.com/newrelic/nri-mssql/actions/runs/8062545746/job/22022501960
```