### PR TITLE
NR-249371: reflect failures in pre-release title

### DIFF
--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -230,6 +230,12 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
           slack-text: "❌ `${{ github.event.repository.full_name }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})."
+
+  update-title-on-failure:
+    if: ${{ always() && failure() }}
+    needs: [test-nix, test-windows, test-integration-nix, build-artifacts, build-win-packages, publish]
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
       - name: Reflect failure in release title
         env:

--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -212,6 +212,12 @@ jobs:
           packageLocation: repo
           stagingRepo: true
           upgrade: false
+      - name: Update pre-release title
+        env:
+          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
+        run: |
+          gh release edit ${{ inputs.tag }} --title "${{ inputs.tag }}"
+
 
   notify-failure:
     if: ${{ always() && failure() }}
@@ -227,6 +233,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Reflect failure in release title
         env:
-          GH_TOKEN: "${{ COREINT_BOT_TOKEN }}"
+          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
         run: |
-          gh release edit ${{ inputs.tag }} --title "${{ inputs.tag }} (not-ready)"
+          gh release edit ${{ inputs.tag }} --title "${{ inputs.tag }} (pre-release-failure)"

--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -76,6 +76,8 @@ on:
         required: true
       COREINT_SLACK_CHANNEL:
         required: true
+      COREINT_BOT_TOKEN:
+        required: true
 
 env:
   # Build scripts inputs are mixed between this env vars and config args.
@@ -222,3 +224,9 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
           slack-text: "❌ `${{ github.event.repository.full_name }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})."
+      - uses: actions/checkout@v4
+      - name: Reflect failure in release title
+        env:
+          GH_TOKEN: "${{ COREINT_BOT_TOKEN }}"
+        run: |
+          gh release edit ${{ inputs.tag }} --title "${{ inputs.tag }} (not-ready)"

--- a/.github/workflows/reusable_trigger_prerelease.yaml
+++ b/.github/workflows/reusable_trigger_prerelease.yaml
@@ -113,7 +113,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.bot_token }}"
         run: |
-          gh release create ${{ steps.release-data.outputs.next-version }} --title ${{ steps.release-data.outputs.next-version }}  --target $(git rev-parse HEAD) --notes-file CHANGELOG.partial.md --prerelease
+          gh release create ${{ steps.release-data.outputs.next-version }} --title "${{ steps.release-data.outputs.next-version }} (artifacts-pending)"  --target $(git rev-parse HEAD) --notes-file CHANGELOG.partial.md --prerelease
       - name: Notify failure via Slack
         if: ${{ failure() }}
         uses: archive/github-actions-slack@master


### PR DESCRIPTION
This PR edits pre-release titles to reflect the corresponding artifacts states:

| State | Title | pre-release |
| - | - | - |
| pre-release created | `vX.Y.Z (artifacts-pending)` | `true` |
| pre-release ready | `vX.Y.Z` | `true` |
| pre-release failure| `vX.Y.Z (pre-release-failure)` | `true` |

This should help us to easily identify failing pre-releases both manually and automatically.

## Out of scope:

Since releases are not promoted automatically (yet), the release workflow is not modified. The release title should also reflect failures when promoting from pre-releases to releases automatically.

## TODO:

- [ ] Move the latest tag when the changes are merged.