### PR TITLE
NR-249372: Promote prereleases to releases

### DIFF
--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -1,0 +1,115 @@
+name: Promote and Trigger Prerelease
+
+# This workflow encompasses two main functions:
+# 1. It checks for the latest successful prerelease, excluding any labeled with "artifacts-pending" or "pre-release-failure",
+#    and promotes it to a full release if suitable. This action should consequently trigger any workflows
+#    that respond to the 'released' event type, ultimately invoking 'reusable_on_release.yaml'.
+#
+# 2. It then triggers the creation of a new prerelease based on specified criteria and included files,
+#    fully automating the release cycle management.
+#
+# This workflow should be triggered merely from the default branch.
+# Manual prerelease creation is fully supported for exceptional cases.
+
+# Usage from the caller workflow:
+# jobs:
+#   release_management:
+#     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3
+#     secrets:
+#       bot_token: ${{ secrets.bot_token }}
+#       slack_channel: ${{ secrets.slack_channel }}
+#       slack_token: ${{ secrets.slack_token }}
+
+on:
+  workflow_call:
+    inputs:
+      block_endpoint:
+        description: This endpoint should respond status 200 for the promotion to continue.
+        required: false
+        type: string
+        default: https://newrelic.github.io/coreint-automation/automatic_release_enable
+    secrets:
+      bot_token:
+        description: "github token"
+        required: true
+      slack_channel:
+        description: "slack channel for sending a message in case of failure"
+        required: true
+      slack_token:
+        description: "slack token for sending the message"
+        required: true
+
+jobs:
+  check_block_endpoint:
+    name: Check block endpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check block endpoint
+        run: |
+          http_status=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.block_endpoint }}")
+
+          if [ "$http_status" != 200 ]; then
+            echo "Fail checking release block endpoint: ${{ inputs.block_endpoint }}"
+            exit 1
+          fi
+
+  promote_prerelease:
+    needs: check_block_endpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote previous prerelease to release
+        env:
+          GH_TOKEN: "${{ secrets.bot_token }}"
+        run: |
+          # Get the date of the latest release.
+          LATEST_RELEASE=$(
+            gh release list --json publishedAt,isLatest -R "${{ github.repository }}" --jq '
+              .[] | select(.isLatest) | .publishedAt | fromdateiso8601
+            '
+          )
+
+          # List all releases, filter by prereleases that was made later than the latest release, sort by date,
+          # reverse because the last one is the most recent and only grab the last prerelease
+          NON_PUBLISHED_PRERELEASE=$(
+            gh release list --json name,publishedAt,isPrerelease,isLatest,tagName -R "${{ github.repository }}" --jq '
+              [
+                  .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE}'))
+              ]
+              | sort_by(.publishedAt |= fromdateiso8601) | reverse | first
+            '
+          )
+
+          # Get prerelease name
+          NON_PUBLISHED_PRERELEASE_NAME=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.name')
+
+          # Check specifically for "artifacts-pending" or "pre-release-failure" conditions
+          if [[ "$NON_PUBLISHED_PRERELEASE_NAME" == *"artifacts-pending"* || "$NON_PUBLISHED_PRERELEASE_NAME" == *"pre-release-failure"* ]]; then
+            echo "Prerelease $NON_PUBLISHED_PRERELEASE_NAME is blocked due to 'artifacts-pending' or 'pre-release-failure'."
+            # Setting an environment variable for conditional steps later on
+            echo "SHOULD_NOTIFY=1" >> $GITHUB_ENV
+          else
+            PRERELEASE_TAG=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.tagName')
+
+            # Promote the prerelease to a full release
+            gh release edit "$PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
+
+            echo "SHOULD_NOTIFY=0" >> $GITHUB_ENV
+          fi
+
+      - name: Notify failure via Slack
+        if: env.SHOULD_NOTIFY == '1'
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
+          slack-channel: ${{ secrets.slack_channel }}
+          slack-text: "❌ `${{ github.event.repository.full_name }}`: [promote prerelease failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})"
+
+  trigger_prerelease:
+    needs: promote_prerelease
+    uses: ./.github/workflows/reusable_trigger_prerelease.yaml
+    secrets:
+      bot_token: ${{ secrets.bot_token }}
+      slack_channel: ${{ secrets.slack_channel }}
+      slack_token: ${{ secrets.slack_token }}
+    with:
+      rt-included-files: go.mod,go.sum,build/Dockerfile

--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -1,4 +1,4 @@
-name: Promote and Trigger Prerelease
+name: Release automation
 
 # This workflow encompasses two main functions:
 # 1. It checks for the latest successful prerelease, excluding any labeled with "artifacts-pending" or "pre-release-failure",
@@ -7,18 +7,12 @@ name: Promote and Trigger Prerelease
 #
 # 2. It then triggers the creation of a new prerelease based on specified criteria and included files,
 #    fully automating the release cycle management.
-#
-# This workflow should be triggered merely from the default branch.
-# Manual prerelease creation is fully supported for exceptional cases.
 
 # Usage from the caller workflow:
 # jobs:
 #   release_management:
 #     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3
-#     secrets:
-#       bot_token: ${{ secrets.bot_token }}
-#       slack_channel: ${{ secrets.slack_channel }}
-#       slack_token: ${{ secrets.slack_token }}
+#     secrets: inherit
 
 on:
   workflow_call:
@@ -28,16 +22,6 @@ on:
         required: false
         type: string
         default: https://newrelic.github.io/coreint-automation/automatic_release_enable
-    secrets:
-      bot_token:
-        description: "github token"
-        required: true
-      slack_channel:
-        description: "slack channel for sending a message in case of failure"
-        required: true
-      slack_token:
-        description: "slack token for sending the message"
-        required: true
 
 jobs:
   check_block_endpoint:
@@ -59,7 +43,7 @@ jobs:
     steps:
       - name: Promote previous prerelease to release
         env:
-          GH_TOKEN: "${{ secrets.bot_token }}"
+          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
         run: |
           # Get the date of the latest release.
           LATEST_RELEASE=$(
@@ -79,37 +63,35 @@ jobs:
             '
           )
 
-          # Get prerelease name
+          # Extract the name and tag from the latest prerelease
           NON_PUBLISHED_PRERELEASE_NAME=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.name')
+          NON_PUBLISHED_PRERELEASE_TAG=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.tagName')    
 
-          # Check specifically for "artifacts-pending" or "pre-release-failure" conditions
-          if [[ "$NON_PUBLISHED_PRERELEASE_NAME" == *"artifacts-pending"* || "$NON_PUBLISHED_PRERELEASE_NAME" == *"pre-release-failure"* ]]; then
-            echo "Prerelease $NON_PUBLISHED_PRERELEASE_NAME is blocked due to 'artifacts-pending' or 'pre-release-failure'."
-            # Setting an environment variable for conditional steps later on
-            echo "SHOULD_NOTIFY=1" >> $GITHUB_ENV
-          else
-            PRERELEASE_TAG=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.tagName')
-
+          # Check if the prerelease name matches its tag and promote if they are the same
+          if [[ "$NON_PUBLISHED_PRERELEASE_NAME" == "$NON_PUBLISHED_PRERELEASE_TAG" ]]; then
             # Promote the prerelease to a full release
-            gh release edit "$PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
-
+            gh release edit "$NON_PUBLISHED_PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
             echo "SHOULD_NOTIFY=0" >> $GITHUB_ENV
+          else
+            # Do not promote and set to notify
+            echo "Prerelease $NON_PUBLISHED_PRERELEASE_NAME is blocked since it does not match with $NON_PUBLISHED_PRERELEASE_TAG"
+            echo "SHOULD_NOTIFY=1" >> $GITHUB_ENV
           fi
 
       - name: Notify failure via Slack
         if: env.SHOULD_NOTIFY == '1'
         uses: archive/github-actions-slack@master
         with:
-          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
-          slack-channel: ${{ secrets.slack_channel }}
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
           slack-text: "❌ `${{ github.event.repository.full_name }}`: [promote prerelease failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})"
 
   trigger_prerelease:
     needs: promote_prerelease
     uses: ./.github/workflows/reusable_trigger_prerelease.yaml
     secrets:
-      bot_token: ${{ secrets.bot_token }}
-      slack_channel: ${{ secrets.slack_channel }}
-      slack_token: ${{ secrets.slack_token }}
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
     with:
       rt-included-files: go.mod,go.sum,build/Dockerfile

--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -74,19 +74,17 @@ jobs:
           NON_PUBLISHED_PRERELEASE_NAME=$(jq -r '.name' <<<"$NON_PUBLISHED_PRERELEASE")
           NON_PUBLISHED_PRERELEASE_TAG=$(jq -r '.tagName' <<<"$NON_PUBLISHED_PRERELEASE")
 
-          # Check if the prerelease name matches its tag and promote if they are the same. In case the prerelase is labeled
+          # Check if the prerelease name matches its tag. Only promote if they are identical. So, in case the prerelase is labeled
           # with "artifacts-pending" or "pre-release-failure" suffixes, it will fail.
-          if [[ "$NON_PUBLISHED_PRERELEASE_NAME" == "$NON_PUBLISHED_PRERELEASE_TAG" ]]; then
-            # Promote the prerelease to a full release
-            gh release edit "$NON_PUBLISHED_PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
-          else
-            # Do not promote and set to notify
+          if [[ "$NON_PUBLISHED_PRERELEASE_NAME" != "$NON_PUBLISHED_PRERELEASE_TAG" ]]; then
             echo "Prerelease $NON_PUBLISHED_PRERELEASE_NAME is blocked since it does not match with $NON_PUBLISHED_PRERELEASE_TAG"
             exit 1
           fi
 
+          gh release edit "$NON_PUBLISHED_PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
+
       - name: Notify failure via Slack
-        if: ${{ always() && failure() }}
+        if: failure()
         uses: archive/github-actions-slack@master
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
@@ -94,6 +92,7 @@ jobs:
           slack-text: "❌ `${{ github.event.repository.full_name }}`: [promote prerelease failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})"
 
   trigger_prerelease:
+    if: always()
     needs: promote_prerelease
     uses: ./.github/workflows/reusable_trigger_prerelease.yaml
     secrets:

--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
         default: https://newrelic.github.io/coreint-automation/automatic_release_enable
+    secrets:
+      COREINT_BOT_TOKEN:
+        required: true
+      COREINT_SLACK_CHANNEL:
+        required: true
+      COREINT_SLACK_TOKEN:
+        required: true
 
 jobs:
   check_block_endpoint:
@@ -46,40 +53,40 @@ jobs:
           GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
         run: |
           # Get the date of the latest release.
-          LATEST_RELEASE=$(
+          LATEST_RELEASE_DATE=$(
             gh release list --json publishedAt,isLatest -R "${{ github.repository }}" --jq '
               .[] | select(.isLatest) | .publishedAt | fromdateiso8601
             '
           )
 
-          # List all releases, filter by prereleases that was made later than the latest release, sort by date,
+          # List all releases, filter by prereleases that were made later than the latest release, sort by date,
           # reverse because the last one is the most recent and only grab the last prerelease
           NON_PUBLISHED_PRERELEASE=$(
-            gh release list --json name,publishedAt,isPrerelease,isLatest,tagName -R "${{ github.repository }}" --jq '
+            gh release list --json name,publishedAt,isPrerelease,tagName -R "${{ github.repository }}" --order desc --jq '
               [
-                  .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE}'))
+                  .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
               ]
-              | sort_by(.publishedAt |= fromdateiso8601) | reverse | first
+              | sort_by(.publishedAt |= fromdateiso8601) | first
             '
           )
 
           # Extract the name and tag from the latest prerelease
-          NON_PUBLISHED_PRERELEASE_NAME=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.name')
-          NON_PUBLISHED_PRERELEASE_TAG=$(echo "$NON_PUBLISHED_PRERELEASE" | jq -r '.tagName')    
+          NON_PUBLISHED_PRERELEASE_NAME=$(jq -r '.name' <<<"$NON_PUBLISHED_PRERELEASE")
+          NON_PUBLISHED_PRERELEASE_TAG=$(jq -r '.tagName' <<<"$NON_PUBLISHED_PRERELEASE")
 
-          # Check if the prerelease name matches its tag and promote if they are the same
+          # Check if the prerelease name matches its tag and promote if they are the same. In case the prerelase is labeled
+          # with "artifacts-pending" or "pre-release-failure" suffixes, it will fail.
           if [[ "$NON_PUBLISHED_PRERELEASE_NAME" == "$NON_PUBLISHED_PRERELEASE_TAG" ]]; then
             # Promote the prerelease to a full release
             gh release edit "$NON_PUBLISHED_PRERELEASE_TAG" --repo "${{ github.repository }}" --draft=false --prerelease=false
-            echo "SHOULD_NOTIFY=0" >> $GITHUB_ENV
           else
             # Do not promote and set to notify
             echo "Prerelease $NON_PUBLISHED_PRERELEASE_NAME is blocked since it does not match with $NON_PUBLISHED_PRERELEASE_TAG"
-            echo "SHOULD_NOTIFY=1" >> $GITHUB_ENV
+            exit 1
           fi
 
       - name: Notify failure via Slack
-        if: env.SHOULD_NOTIFY == '1'
+        if: ${{ always() && failure() }}
         uses: archive/github-actions-slack@master
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}


### PR DESCRIPTION
This PR introduces a new reusable workflow, `reusable_promote_prerelease.yaml`, designed to automate the promotion of validated prereleases to full releases. It streamlines our release process by ensuring only prereleases without `"artifacts-pending"` or `"pre-release-failure"` labels are promoted.

I also added the capability of blocking the process by leveraging the block endpoint check.