### PR TITLE
Allow reusable release to be used with image repos

### DIFF
--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -22,6 +22,26 @@ on:
         required: false
         type: string
         default: https://newrelic.github.io/coreint-automation/automatic_release_enable
+      rt-excluded-dirs:
+        description: Release-toolkit excluded-dirs field.
+        required: false
+        type: string
+        default: ""
+      rt-excluded-files:
+        description: Release-toolkit excluded-files field.
+        required: false
+        type: string
+        default: ""
+      rt-included-dirs:
+        description: Release-toolkit included-dirs field.
+        required: false
+        type: string
+        default: ""
+      rt-included-files:
+        description: Release-toolkit included-files field.
+        required: false
+        type: string
+        default: go.mod,go.sum,build/Dockerfile
     secrets:
       COREINT_BOT_TOKEN:
         required: true
@@ -100,4 +120,7 @@ jobs:
       slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
       slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
     with:
-      rt-included-files: go.mod,go.sum,build/Dockerfile
+      excluded-dirs: "${{ inputs.rt-excluded-dirs }}"
+      excluded-files: "${{ inputs.rt-excluded-files }}"
+      included-dirs: "${{ inputs.rt-included-dirs }}"
+      included-files: "${{ inputs.rt-included-files }}"


### PR DESCRIPTION
The reusable prerelease is already used on repositories that have images on a different path or required release toolkit to monitor different files.

The two examples:
 * https://github.com/newrelic/infrastructure-bundle/blob/043dbe88990731586bcadc0bea94a00345e9cc41/.github/workflows/trigger_prerelease.yml#L15-L16
 * https://github.com/newrelic/nri-ecs/blob/257396a02af6f4bd373415d77ef988994a9dd2e3/.github/workflows/trigger_prerelease.yml#L19-L20

This keeps the defaults as it is and should cover most of the OHIs but open the possibility to reuse this pipeline with more repositories.