### PR TITLE
Fix invalid input

### DIFF
--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -120,7 +120,7 @@ jobs:
       slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
       slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
     with:
-      excluded-dirs: "${{ inputs.rt-excluded-dirs }}"
-      excluded-files: "${{ inputs.rt-excluded-files }}"
-      included-dirs: "${{ inputs.rt-included-dirs }}"
-      included-files: "${{ inputs.rt-included-files }}"
+      rt-excluded-dirs: "${{ inputs.rt-excluded-dirs }}"
+      rt-excluded-files: "${{ inputs.rt-excluded-files }}"
+      rt-included-dirs: "${{ inputs.rt-included-dirs }}"
+      rt-included-files: "${{ inputs.rt-included-files }}"


### PR DESCRIPTION
We have pipelines failing with this error:
```
The workflow is not valid. newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3 (Line: 123, Col: 22): Invalid input, excluded-dirs is not defined in the referenced workflow. newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3 (Line: 124, Col: 23): Invalid input, excluded-files is not defined in the referenced workflow.
```
Like here: https://github.com/newrelic/nri-ecs/actions/runs/8740290131
Note: on the run above, the first run failed because I forgot to move the `v3` tag, is the second run the one failing with the issue this PR fixes.

The this was a copy and paste leftover as I copy the inputs from the pre-release pipeline instead of the trigger prerelease where the inputs are prefixed with `rt-`.

I would prefer to remove the prefix to keep consistency but it would make another breaking change that I do not want to deal with it now.
