### PR TITLE
Add tool to list open PRs

### DIFF
--- a/tools/common-functions.sh
+++ b/tools/common-functions.sh
@@ -1,7 +1,7 @@
 # This file must be used with "source common.sh". You cannot run it directly
 if [ "${BASH_SOURCE-}" = "$0" ]; then
     echo "You must source this script: \$ source $0" >&2
-    exit 1
+    return
 fi
 
 ORG="newrelic";

--- a/tools/list-open-prs.sh
+++ b/tools/list-open-prs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname $(readlink -f $0))/common-functions.sh"
+
+# Listing all repositories that start with `nri-` that belongs to coreint
+gh api --paginate "/teams/${TEAM_ID}/repos" --jq '.[] | select(.name | startswith("nri-")) | .name' | \
+while read REPO_NAME; do
+    PRS=$(gh pr list -R "${ORG}/${REPO_NAME}" \
+        --json "isDraft,author,number,title,url" \
+        --jq ' .[] | select(.isDraft == false) | "#" + (.number|tostring) + ";" + .title + " (" + .author.login + ");" + .url'
+    )
+    if [ -z "$PRS" ]; then
+        exit 0
+    fi
+
+    echo "⚠️ The repository ${REPO_NAME} has has unmerged PRs that are not marked as draft:"
+    column -t -s\; <<<"${PRS}"
+
+    echo
+done


### PR DESCRIPTION
I know that there is a panel in GitHub for open PRs but not only I would have to add filters to filter Draft PRs but also to filter all repos that are open source that I am subscribed (like OTel or personal projects)

To reduce the amount of noise and have a way better view, this script should do the trick.

Example of output:
```
⚠️ The repository nri-mysql has has unmerged PRs that are not marked as draft:
#156  chore(deps): update golang version to v1.22.6(app/renovate)  https://github.com/newrelic/nri-mysql/pull/156

⚠️ The repository nri-cassandra has has unmerged PRs that are not marked as draft:
#202  chore(deps): update golang version to v1.22.6(app/renovate)    https://github.com/newrelic/nri-cassandra/pull/202
#147  fix(deps): update module gopkg.in/yaml.v2 to v3(app/renovate)  https://github.com/newrelic/nri-cassandra/pull/147

```