### PR TITLE
Upgrade Golang versions automatically when new patch version is released

### DIFF
--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -35,6 +35,8 @@
       // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
       // according to the SemVer spec.
       "matchCurrentVersion": "!/^(0|v0)/",
+      // Exclude golang dependency so golang version in Docker, gomod files is not auto-merged.
+      "excludeDepNames": ["golang", "go"],
       // Renovate will do the following when detecting a new dependency bump:
       "automerge": true,
       "automergeType": "branch",
@@ -48,8 +50,8 @@
       // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
       // according to the SemVer spec.
       "matchCurrentVersion": "!/^(0|v0)/",
-      // Exclude golang dependency so golang version in Docker files is not auto-merged.
-      "excludeDepNames": ["golang"],
+      // Exclude golang dependency so golang version in Docker, gomod files is not auto-merged.
+      "excludeDepNames": ["golang", "go"],
       "automerge": true,
       "automergeType": "branch",
       "pruneBranchAfterAutomerge": true
@@ -58,29 +60,37 @@
         // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
         // Enable golang version bumps in 'go.mod' but disable auto-merge.
         "matchDatasources": ["golang-version"],
-        "rangeStrategy": "bump",
-        // The packageRules are overrided/merged, therefore this rule needs to set automerge to false explicitly.
-        "automerge": false,
-    },
-    {
-        // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
-        // Enable golang version bumps in 'go.mod' but disable auto-merge.
-        "matchDatasources": ["golang-version"],
-        // We always merge patch updates for golang.
-        "matchUpdateTypes": ["patch"],
-        // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
-        // according to the SemVer spec.
-        "matchCurrentVersion": "!/^(0|v0)/",
-        // Renovate will do the following when detecting a new dependency bump:
-        "automerge": true,
-        "automergeType": "pr",
-        "pruneBranchAfterAutomerge": true
+        "rangeStrategy": "bump"
     },
     {
         // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
         // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
+        // Group minor and major versions with groupName golang version
         "matchPackageNames": ["golang", "go"],
-        "groupName": "golang version"
+        "matchUpdateTypes": ["minor", "major"],
+        "groupName": "golang version",
+        "automerge": false,
+        "pruneBranchAfterAutomerge": true,
+        "platformAutomerge": true
+    },
+    {
+        // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
+        // Enable golang version bumps in 'go.mod'.
+        "matchDatasources": ["golang-patch-version"],
+        "rangeStrategy": "bump"
+    },
+    {
+      // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
+      // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
+      // Group patchversions with groupName golang patch version
+      "description": "Automerge go patch version updates",
+      "matchPackageNames": ["golang", "go"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "golang patch version",
+      "automerge": true,
+      "pruneBranchAfterAutomerge": true,
+      "platformAutomerge": true
     }
+    
   ]
 }

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -63,6 +63,20 @@
         "automerge": false,
     },
     {
+        // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
+        // Enable golang version bumps in 'go.mod' but disable auto-merge.
+        "matchDatasources": ["golang-version"],
+        // We always merge patch updates for golang.
+        "matchUpdateTypes": ["patch"],
+        // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
+        // according to the SemVer spec.
+        "matchCurrentVersion": "!/^(0|v0)/",
+        // Renovate will do the following when detecting a new dependency bump:
+        "automerge": true,
+        "automergeType": "pr",
+        "pruneBranchAfterAutomerge": true
+    },
+    {
         // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
         // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
         "matchPackageNames": ["golang", "go"],

--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -65,13 +65,13 @@
     {
         // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
         // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
-        // Group minor and major versions with groupName golang version
+        // Group golang & go packages minor, major versions with groupName "golang version"
+        // Disabled automerge for golang & go packages minor, major version updates
         "matchPackageNames": ["golang", "go"],
         "matchUpdateTypes": ["minor", "major"],
         "groupName": "golang version",
         "automerge": false,
-        "pruneBranchAfterAutomerge": true,
-        "platformAutomerge": true
+        "pruneBranchAfterAutomerge": true
     },
     {
         // go.mod golang-version is not updated by default, check <https://github.com/renovatebot/renovate/issues/16715>.
@@ -82,7 +82,8 @@
     {
       // Group the Dockerfile go bump ("golang" package) and the go.mod go bump ("go" package) together
       // check <https://docs.renovatebot.com/configuration-options/#groupname> for details about grouping.
-      // Group patchversions with groupName golang patch version
+      // Group golang & go packages patch versions with groupName "golang patch version"
+      // Enabled automerge for golang & go packages patch version updates
       "description": "Automerge go patch version updates",
       "matchPackageNames": ["golang", "go"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Changes in this PR: 
- Separated go, golang package updates (from all patch, minor updates rule)
- Grouped go, golang package with **minor**, **major** versions under a single group name - `golang version`
- Grouped go, golang package with **patch** versions with name - `golang patch version`
- Enabled version bump with group name - `golang version` but disabled automerge
- Enabled both version bump and automerge for `golang patch version` group

Steps that I went through to test the auto-merge works as expected

TestCase-1: If there is a new GoLang Patch version released the renovate bot should auto-merge the PR.

1. Created a fork of the nri-mysql repo
2. Copied the config from `coreint-automation/renovate-base.json5` and added it to forked `nri-mysql/.github/renovate.json5`
3. Updated the config to auto-merge whenever new GoLang patch version is released
4. Installed the renovate app by providing the billing details(name, address) in my profile
5. Selected the forked nr-mysql repo to provide access to renovate for running and detecting changes in the repo
7. The renovate job ran and detected new GoLang patch version 1.23.2->1.23.3
8. Renovate bot has raised a PR for upgrading patch version, waited for all the checks to pass and auto-merged it after an hour.

TestCase-2: If there is a new GoLang minor version released the renovate bot should raise PR but not auto-merge it.

1. Downgraded the version in the forked nri-mysql repo from 1.23.3 -> 1.22.2 and merged the commits
2. Renovate bot detected the new minor version released i.e 1.23.3 and raised a PR to upgrade the GoLang version but didn't auto-merge it.