### PR TITLE
Make test-nix optional

### DIFF
--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -30,6 +30,10 @@ on:
         required: false
         type: boolean
         default: true
+      run_test_nix:
+        required: false
+        type: boolean
+        default: true
       run_test_windows:
         required: false
         type: boolean
@@ -87,6 +91,7 @@ env:
 
 jobs:
   test-nix:
+    if: ${{ inputs.run_test_nix }}
     uses: ./.github/workflows/_test_nix.yaml
 
   test-windows:

--- a/.github/workflows/reusable_push_pr.yaml
+++ b/.github/workflows/reusable_push_pr.yaml
@@ -9,6 +9,10 @@ on:
       integration:
         required: false
         type: string
+      run_test_nix:
+        required: false
+        type: boolean
+        default: true
       run_test_windows:
         required: false
         type: boolean
@@ -44,6 +48,7 @@ jobs:
     uses: ./.github/workflows/_static_analysis.yaml
 
   test-nix:
+    if: ${{ inputs.run_test_nix }}
     uses: ./.github/workflows/_test_nix.yaml
 
   test-windows:


### PR DESCRIPTION
The job `test-nix` was running without condition in the `reusable_push_pr` and `reusable_pre_release` workflows.

It can now be optional by providing `run-test-nix` input.