### PR TITLE
add dest_prefix input parameter

### DIFF
--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -54,6 +54,11 @@ on:
         required: false
         type: boolean
         default: false
+      dest_prefix:
+        description: "destination s3 path prefix for pushing the artifacts"
+        required: false
+        type: string
+        default: "infrastructure_agent/"
 
     secrets:
       OHAI_AWS_ROLE_ARN_STAGING:
@@ -200,6 +205,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
           aws_s3_bucket_name: "nr-downloads-ohai-staging"
           aws_s3_lock_bucket_name: "onhost-ci-lock-staging"
+          dest_prefix: ${{ inputs.dest_prefix }}
           # used for signing package stuff
           gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}


### PR DESCRIPTION
### What?
Add a new optional input parameter to the reusable prerelase workflow with a default value of `infrastructure_agent/`

### Why?
Allows OHIs to specify a different path for testing the package creation and uploads without impacting the staging s3. The installation test will still use the default path, which should be changed as part of [NR-340027](https://new-relic.atlassian.net/browse/NR-340027)


[NR-340027]: https://new-relic.atlassian.net/browse/NR-340027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ