### PR TITLE
NR-340296 Update renovate config to update golang version for Dockerfile ARG

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
       "extractVersionTemplate": "(?<version>1\\.22\\.\\d+)"
     },
     {
+      "customType": "regex",
       "fileMatch": ["^\\.github/workflows/build_publish_builder_image\\.yaml$"],
       "matchStrings": [
         "go-version:\\s*\\[\\s*(?<currentValue1>1\\.22\\.\\d+),\\s*(?<currentValue2>1\\.23\\.\\d+)\\s*\\]"

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,9 @@
   "extends": [
     "config:recommended"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^\\.github/workflows/build_publish_builder_image\\.yaml$"],
       "matchStrings": [
         "go-version:\\s*\\[\\s*(?<currentValue1>1\\.22\\.\\d+),\\s*(?<currentValue2>1\\.23\\.\\d+)\\s*\\]"

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,43 @@
   "extends": [
     "config:recommended"
   ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.github/workflows/build_publish_builder_image\\.yaml$"],
+      "matchStrings": [
+        "go-version:\\s*\\[\\s*(?<currentValue1>1\\.22\\.\\d+),\\s*(?<currentValue2>1\\.23\\.\\d+)\\s*\\]"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang-1.22",
+      "currentValueTemplate": "{{{currentValue1}}}",
+      "extractVersionTemplate": "(?<version>1\\.22\\.\\d+)"
+    },
+    {
+      "fileMatch": ["^\\.github/workflows/build_publish_builder_image\\.yaml$"],
+      "matchStrings": [
+        "go-version:\\s*\\[\\s*(?<currentValue1>1\\.22\\.\\d+),\\s*(?<currentValue2>1\\.23\\.\\d+)\\s*\\]"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang-1.23",
+      "currentValueTemplate": "{{{currentValue2}}}",
+      "extractVersionTemplate": "(?<version>1\\.23\\.\\d+)"
+    }
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": [ "minor" ],
-      "matchPackageNames": [ "aquasecurity/trivy-action" ],
+      "description": "Automerge patch updates for Go versions 1.22.x and 1.23.x",
+      "matchDatasources": ["golang-version"],
+      "matchPackageNames": ["golang-1.22", "golang-1.23"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType":"pr",
+      "prCreation": "immediate",
+      "pruneBranchAfterAutomerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "matchPackageNames": ["aquasecurity/trivy-action"],
       "automerge": true,
       "automergeType": "branch",
       "pruneBranchAfterAutomerge": true


### PR DESCRIPTION
Changes in this PR

Configured renovate.json to update the patch versions for each version in the list `go-version` present in `build_publish_builder_image.yaml` file.

Tested the above by creating a fork of this repo and renovate has created [PR1](https://github.com/sairaj18/coreint-automation-test/pull/9), [PR2](https://github.com/sairaj18/coreint-automation-test/pull/7) (It has created PR1 with automerge true But, I merged the PR1 manually in-order to see if the PR2 gets raised)