### PR TITLE
add docker and buildx to the builder image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,8 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG GO_VERSION=1.23.2
 ARG ARCH='amd64'
 ARG GH_VERSION='2.61.0'
+ARG DOCKER_VERSION='24.0.5'
+ARG BUILDX_VERSION='0.11.2'
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -43,6 +45,16 @@ ENV GOPATH="/go"
 # Default value of -buildvcs is auto, more info:
 # https://github.com/kubernetes-sigs/gateway-api/pull/2302#issuecomment-1855818388
 ENV GOFLAGS="-buildvcs=false"
+
+# Install Docker
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz -o docker.tgz && \
+    tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
+    rm docker.tgz
+
+# Install Buildx
+RUN mkdir -p ~/.docker/cli-plugins && \
+    curl -sSL https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${ARCH} -o ~/.docker/cli-plugins/docker-buildx && \
+    chmod +x ~/.docker/cli-plugins/docker-buildx
 
 # Since the user does not match the owners of the repo "git rev-parse --is-inside-work-tree" fails and goreleaser does not populate projectName
 # https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor


### PR DESCRIPTION
### Summary
[nri-prometheus](https://github.com/newrelic/nri-prometheus) uses `buildx` to create images using `goreleaser`. Therefore, adding these in the centralized builder image.

### How has it been tested?

<details>
<summary>Building Image</summary>

```log
❯ docker build -f build/Dockerfile --platform=linux/amd64 -t fips-test-img .
[+] Building 30.6s (12/12) FINISHED                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                          0.0s
 => => transferring dockerfile: 2.21kB                                        0.0s
 => [internal] load metadata for docker.io/library/ubuntu:16.04               1.1s
 => [internal] load .dockerignore                                             0.0s
 => => transferring context: 2B                                               0.0s
 => [1/8] FROM docker.io/library/ubuntu:16.04@sha256:1f1a2d56de1d604801a9671  0.0s
 => CACHED [2/8] RUN apt-get update && apt-get install -y     gnupg-agent     0.0s
 => CACHED [3/8] RUN curl -sSL https://golang.org/dl/go1.23.2.linux-amd64.ta  0.0s
 => [4/8] RUN curl -fsSL https://download.docker.com/linux/static/stable/x8  11.5s
 => [5/8] RUN mkdir -p ~/.docker/cli-plugins &&     curl -sSL https://githu  11.2s
 => [6/8] RUN git config --global --add safe.directory '*'                    0.1s
 => [7/8] RUN curl -L https://github.com/cli/cli/releases/download/v2.61.0/g  5.1s
 => [8/8] RUN dpkg -i gh_2.61.0_linux_amd64.deb                               0.5s
 => exporting to image                                                        1.2s 
 => => exporting layers                                                       1.2s 
 => => writing image sha256:f52e03d6e96aff6c86873712f876e0808f6cc54c634919f6  0.0s 
 => => naming to docker.io/library/fips-test-img                              0.0s 
                                                                                   
View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/z6wjt8yd7xy61rexv5qvmc8sd

What's next:
```
</details>

<details>
<summary>Using Image</summary>

```log
❯ docker run -d -it -v $(pwd):/app -v /var/run/docker.sock:/var/run/docker.sock --platform linux/amd64 fips-test-img
6945b77579f08220d72298d00d30d2f815bfec203862913ecc32b9a3c9299ce2
❯ dkr ps -a
CONTAINER ID   IMAGE                                                             COMMAND       CREATED          STATUS          PORTS     NAMES
6945b77579f0   fips-test-img                                                     "/bin/bash"   4 seconds ago    Up 3 seconds              compassionate_lederberg
92f6ec307615   fips-test-img                                                     "/bin/bash"   13 minutes ago   Up 13 minutes             reverent_cannon
e39fd9953a92   ghcr.io/newrelic/coreint-automation:latest-go1.23.3-ubuntu16.04   "/bin/bash"   4 days ago       Up 4 days                 zealous_almeida
❯ dkrbash 6945b77579f0
root@6945b77579f0:/# cd app
root@6945b77579f0:/app# make bin/goreleaser
===> prometheus === [bin/goreleaser] Installing goreleaser v2.4.4
===> prometheus === [bin/goreleaser] goreleaser downloaded
root@6945b77579f0:/app# TAG=v2.21.7-next TAG_SUFFIX=-next bin/goreleaser release --snapshot --clean --config=.goreleaser.yml --skip=validate
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=709432e9538b12a8c40e458ac3c19b2284abd311 branch=NR-287123-add-fips-compliant-pkgs current_tag=v2.21.7 previous_tag=nri-prometheus-2.1.19 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • pipe skipped                                   reason=release is disabled
  • snapshotting
    • building snapshot...                           version=v2.21.7-next
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
    • took: 12s
  • build prerequisites
  • building binaries
    • building                                       binary=dist/nri-prometheus-win_windows_amd64_v1/nri-prometheus.exe
    • building                                       binary=dist/nri-prometheus-nix-fips_linux_arm64_v8.0/nri-prometheus
    • building                                       binary=dist/nri-prometheus-nix_darwin_arm64_v8.0/nri-prometheus
    • building                                       binary=dist/nri-prometheus-nix-fips_linux_amd64_v1/nri-prometheus
    • building                                       binary=dist/nri-prometheus-win_windows_386_sse2/nri-prometheus.exe
    • building                                       binary=dist/nri-prometheus-nix_linux_386_sse2/nri-prometheus
    • running hook                                   hook=build/windows/set_exe_properties.sh v2.21.7-next "prometheus"
    • running hook                                   hook=build/windows/set_exe_properties.sh v2.21.7-next "prometheus"
    • building                                       binary=dist/nri-prometheus-nix_linux_arm64_v8.0/nri-prometheus
    • building                                       binary=dist/nri-prometheus-nix_darwin_amd64_v1/nri-prometheus
    • building                                       binary=dist/nri-prometheus-nix_linux_arm_6/nri-prometheus
    • building                                       binary=dist/nri-prometheus-nix_linux_amd64_v1/nri-prometheus
    • took: 6m29s
  • archives
    • creating                                       archive=dist/nri-prometheus-amd64.v2.21.7-next_dirty.zip
    • creating                                       archive=dist/nri-prometheus-fips_linux_v2.21.7-next_arm64_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus_linux_v2.21.7-next_arm64_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus_darwin_v2.21.7-next_arm64_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus_linux_v2.21.7-next_arm_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus_linux_v2.21.7-next_amd64_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus_linux_v2.21.7-next_386_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus-386.v2.21.7-next_dirty.zip
    • creating                                       archive=dist/nri-prometheus_darwin_v2.21.7-next_amd64_dirty.tar.gz
    • creating                                       archive=dist/nri-prometheus-fips_linux_v2.21.7-next_amd64_dirty.tar.gz
    • took: 11s
  • calculating checksums
  • docker images
    • building docker image                          image=newrelic/nri-prometheus:v2.21.7-next-next-arm
    • building docker image                          image=newrelic/nri-prometheus-fips:v2.21.7-next-next-arm64
    • building docker image                          image=newrelic/nri-prometheus:v2.21.7-next-next-amd64
    • building docker image                          image=newrelic/nri-prometheus:v2.21.7-next-next-arm64
    • building docker image                          image=newrelic/nri-prometheus-fips:v2.21.7-next-next-amd64
    • took: 11s
  • writing artifacts metadata
  • release succeeded after 7m3s
  • thanks for using goreleaser!
```
</details>