### PR TITLE
add fips test action in step in reusable prerelease

### DIFF
--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -139,6 +139,10 @@ jobs:
           # The upload script expects this to authenticate.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make ci/prerelease
+      - uses: newrelic/coreint-automation/test-fips-action@v3
+        if: ${{ inputs.upload_fips_packages }}
+        with:
+          binaries_path: "./dist"
       - name: Test package installability
         if: ${{ inputs.test_package }}
         uses: newrelic/integrations-pkg-test-action/linux@v1

--- a/test-fips-action/action.yml
+++ b/test-fips-action/action.yml
@@ -1,0 +1,30 @@
+name: Check FIPS binaries for compliance
+description: Check FIPS compliance for binaries
+inputs:
+  binaries_path:
+    required: false
+    default: "./dist"
+    description: "Path to the binaries to check for FIPS compliance, e.g. './dist'"
+runs:
+  using: "composite"
+  steps:
+    - name: Test binaries for FIPS compliance
+      shell: bash
+      run: |
+        find "${{ inputs.binaries_path }}" -type d -name '*-fips*' | while read -r dir; do
+          find "$dir" -type f | while read -r file; do
+            if [ -x "$file" ]; then
+              echo "Checking FIPS mode for binary: $file"
+              # Inline script to check for FIPS-related strings
+              FIPS_STRINGS=$(strings "$file" | grep -i -e fips -e "FIPS_mode_set" -e "FIPS 140-2")
+              if [ -n "$FIPS_STRINGS" ]; then
+                echo "The binary '$file' may be built with FIPS mode. Found the following indicators:"
+                echo "$FIPS_STRINGS"
+              else
+                echo "No FIPS-related indicators found in the binary '$file'."
+                exit 1
+              fi
+              echo "----------------------------------------"
+            fi
+          done
+        done


### PR DESCRIPTION
## Summary
Add fips-test action that checks all the binaries in a given folder. It checks subfolders with name: `*-fips*` and any binary inside those folders should be fips compiled.

## Testing
https://github.com/newrelic/nri-redis/actions/runs/12273589913/job/34244742644