### PR TITLE
fix: update tools team-id

### DIFF
--- a/tools/common-functions.sh
+++ b/tools/common-functions.sh
@@ -6,8 +6,8 @@ fi
 
 ORG="newrelic";
 # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#get-a-team-by-name
-# gh api /orgs/newrelic/teams/coreint | jq .id
-TEAM_ID="3626876";
+# gh api /orgs/newrelic/teams/ohai | jq .id
+TEAM_ID="11525403";
 
 reference_status () {
     REPOSITORY_SLUG="$1"


### PR DESCRIPTION
The `list-not-released-prereleases.sh` script was failing due to a deprecated team id. This PR updates it and also skips repositories not publishing releases.