### PR TITLE
Added slack token and channel to workflow secrets

### DIFF
--- a/.github/workflows/reusable_image_release.yaml
+++ b/.github/workflows/reusable_image_release.yaml
@@ -63,6 +63,10 @@ on:
       aws_access_key_secret:
         description: 'AWS key secret'
         required: false
+      slack_channel:
+        required: true
+      slack_token:
+        required: true
 
 env:
   GITHUB_TOKEN: ${{ secrets.bot_token }}
@@ -194,8 +198,8 @@ jobs:
       - name: Notify failure via Slack
         uses: archive/github-actions-slack@master
         with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
+          slack-channel: ${{ secrets.slack_channel }}
           slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [image release failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."
 
   update-title-on-failure:

--- a/.github/workflows/reusable_nightly.yaml
+++ b/.github/workflows/reusable_nightly.yaml
@@ -7,6 +7,10 @@ on:
           required: true
         docker_password:
           required: true
+        slack_channel:
+          required: true
+        slack_token:
+          required: true
 
       inputs:
         target_branches:
@@ -123,6 +127,6 @@ jobs:
       - name: Notify failure via Slack
         uses: archive/github-actions-slack@master
         with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
+          slack-channel: ${{ secrets.slack_channel }}
           slack-text: "❌ `${{ inputs.docker_image }}`: [Nightly tests/release failed](${{ github.server_url }}/${{ inputs.docker_image }}/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
The notify steps in both the reusable nightly and reusable image release workflows were failing because `COREINT_SLACK_TOKEN` and `COREINT_SLACK_CHANNEL` were not being passed as secrets.

They are now required to be passed to these workflows.