### PR TITLE
Fix: golangci lint breaks with v1.64.2

### DIFF
--- a/.github/workflows/_static_analysis.yaml
+++ b/.github/workflows/_static_analysis.yaml
@@ -14,10 +14,10 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
-          skip-cache: true
+          version: v1.63
       - name: Check if CHANGELOG is valid
         uses: newrelic/release-toolkit/validate-markdown@v1


### PR DESCRIPTION
Latest version of golang-lint breaks our CI. So, fixing it to v1.63. We need to identify and fix it soon. Created https://new-relic.atlassian.net/browse/NR-368969 to fix this.