### PR TITLE
fix: remove sorting of results after fetching releases in desc order

### DIFF
--- a/.github/workflows/reusable_release_automation.yaml
+++ b/.github/workflows/reusable_release_automation.yaml
@@ -86,7 +86,7 @@ jobs:
               [
                   .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
               ]
-              | sort_by(.publishedAt |= fromdateiso8601) | first
+              | first
             '
           )
 


### PR DESCRIPTION
Assumption: The reusable release automation [workflow](https://github.com/newrelic/coreint-automation/blob/6402d3e2f638fc7781744f85ca97686b655ae73b/.github/workflows/reusable_release_automation.yaml#L83) has to fetch the latest pre-release that is available after the last release.

Existing Logic of the reusable release automation workflow 
1. Fetches the list of releases in desc order of the publishedAt date-time
2. Filters the list to get pre-releases that are created after the last release
3. Sort the pre-releases by the publishedAt time and get the first value in the filtered results.

Changes In the PR - removed the sorting of pre-releases as it is re-ordering the results from descending to ascending and the final result is the 1st pre-release that has been created after the last release. But we need the last pre-release that has been created(latest pre-release) after the last release.

<details><summary>Testing Details</summary>
<p>

```shell
saanamsairajyadav@FDJV7H6TVP nri-mysql % gh release list --json name,publishedAt,isPrerelease,tagName -R "newrelic/nri-mssql" --order desc --jq '
      [
          .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
      ]
      | first
    '
{
  "isPrerelease": true,
  "name": "v2.17.3 TEST",
  "publishedAt": "2025-03-20T12:42:07Z",
  "tagName": "v2.17.3"
}
saanamsairajyadav@FDJV7H6TVP nri-mysql %  gh release list --json name,publishedAt,isPrerelease,tagName -R "newrelic/nri-mssql" --order desc --jq '
      [
          .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
      ]
    '
[
  {
    "isPrerelease": true,
    "name": "v2.17.3 TEST",
    "publishedAt": "2025-03-20T12:42:07Z",
    "tagName": "v2.17.3"
  },
  {
    "isPrerelease": true,
    "name": "v2.17.2",
    "publishedAt": "2025-03-12T07:06:22Z",
    "tagName": "v2.17.2"
  },
  {
    "isPrerelease": true,
    "name": "v2.17.1 ⚠️ ⚠️ ⚠️ ",
    "publishedAt": "2025-03-11T09:36:35Z",
    "tagName": "v2.17.1"
  }
]
saanamsairajyadav@FDJV7H6TVP nri-mysql % gh release list --json name,publishedAt,isPrerelease,tagName -R "newrelic/nri-mssql" --order desc --jq ' 
      [
          .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
      ]
      | sort_by(.publishedAt |= fromdateiso8601)        
    '
[
  {
    "isPrerelease": true,
    "name": "v2.17.1 ⚠️ ⚠️ ⚠️ ",
    "publishedAt": "2025-03-11T09:36:35Z",
    "tagName": "v2.17.1"
  },
  {
    "isPrerelease": true,
    "name": "v2.17.2",
    "publishedAt": "2025-03-12T07:06:22Z",
    "tagName": "v2.17.2"
  },
  {
    "isPrerelease": true,
    "name": "v2.17.3 TEST",
    "publishedAt": "2025-03-20T12:42:07Z",
    "tagName": "v2.17.3"
  }
]
saanamsairajyadav@FDJV7H6TVP nri-mysql % gh release list --json name,publishedAt,isPrerelease,tagName -R "newrelic/nri-mssql" --order desc --jq '
      [
          .[] | select( .isPrerelease and ((.publishedAt | fromdateiso8601) > '${LATEST_RELEASE_DATE}'))
      ]
      | sort_by(.publishedAt |= fromdateiso8601) | first
    '
{
  "isPrerelease": true,
  "name": "v2.17.1 ⚠️ ⚠️ ⚠️ ",
  "publishedAt": "2025-03-11T09:36:35Z",
  "tagName": "v2.17.1"
}
saanamsairajyadav@FDJV7H6TVP nri-mysql % 
``` 

</p>
</details> 