### PR TITLE
NR-403516 : move all CI pipelines to ubuntu-latest

### DIFF
--- a/.github/workflows/_test_build_fake_prerelease.yaml
+++ b/.github/workflows/_test_build_fake_prerelease.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   test-build-nix:
     name: Test binary compilation for all platforms:arch
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: |


### PR DESCRIPTION
- Update pipelines from `ubuntu-xx` runners to `ubuntu-latest `