### PR TITLE
Upgraded runner used for publishing

### DIFF
--- a/.github/workflows/reusable_on_release.yaml
+++ b/.github/workflows/reusable_on_release.yaml
@@ -74,7 +74,7 @@ on:
 jobs:
   publish-to-s3:
     name: Send release assets to S3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Publish to S3 action
         uses: newrelic/infrastructure-publish-action@v1

--- a/.github/workflows/reusable_pre_release.yaml
+++ b/.github/workflows/reusable_pre_release.yaml
@@ -214,7 +214,7 @@ jobs:
     # Currently behavior of GHA skips the job if any 'needs' is skipped(Windows tests disabled), so the next condition is needed.
     # Runs always that 'needs' finishes if they are not cancelled nor failed
     if: ${{ always() && !cancelled() && !failure() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Publish to S3 action
         uses: newrelic/infrastructure-publish-action@v1


### PR DESCRIPTION
The standard github runner is running out of disk space while publishing packages to S3.
Upgrading to the 4 core linux runner.