### PR TITLE
feat: daily slack notification for automatic release

### DIFF
--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -174,6 +174,46 @@ jobs:
           PRERELEASE_INFO=""
           DAY_NUM="${{ steps.get_day.outputs.DAY_NUMBER }}"
           
+          # Function to compare semantic versions
+          # Returns 0 if version1 > version2, 1 otherwise
+          compare_versions() {
+            local v1="${1#v}"  # Remove 'v' prefix if present
+            local v2="${2#v}"
+            
+            # Handle empty/null versions
+            [ -z "$v2" ] && return 0
+            [ -z "$v1" ] && return 1
+            
+            # Split versions into components
+            IFS='.' read -r -a ver1 <<< "$v1"
+            IFS='.' read -r -a ver2 <<< "$v2"
+            
+            # Compare major.minor.patch
+            for i in 0 1 2; do
+              local num1="${ver1[$i]:-0}"
+              local num2="${ver2[$i]:-0}"
+              
+              # Remove any non-numeric suffix (like -rc1, -beta)
+              num1="${num1%%-*}"
+              num2="${num2%%-*}"
+              
+              if [ "$num1" -gt "$num2" ]; then
+                return 0
+              elif [ "$num1" -lt "$num2" ]; then
+                return 1
+              fi
+            done
+            
+            # If base versions are equal, pre-release < release
+            if [[ "$v1" == *"-"* ]] && [[ "$v2" != *"-"* ]]; then
+              return 1
+            elif [[ "$v1" != *"-"* ]] && [[ "$v2" == *"-"* ]]; then
+              return 0
+            fi
+            
+            return 1  # versions are equal or v1 <= v2
+          }
+          
           # Get list of repos for today
           case $DAY_NUM in
             1) REPOS="nri-consul nri-mysql nri-memcached nri-redis nri-varnish nri-discovery nri-apache nri-postgresql" ;;
@@ -187,7 +227,7 @@ jobs:
           for repo in $REPOS; do
             echo "Checking releases for newrelic/${repo}..."
             
-            # Using GitHub API to check for pre-releases
+            # Using GitHub API to check for releases
             RESPONSE=$(curl -s \
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
@@ -195,11 +235,23 @@ jobs:
             
             # Check if we got a valid response
             if echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+              # Get latest release (non-prerelease)
+              LATEST_RELEASE=$(echo "$RESPONSE" | jq -r '.[] | select(.prerelease==false) | .tag_name' | head -1)
+              
+              # Get latest pre-release
               LATEST_PRERELEASE=$(echo "$RESPONSE" | jq -r '.[] | select(.prerelease==true) | .tag_name' | head -1)
               
               if [ -n "$LATEST_PRERELEASE" ] && [ "$LATEST_PRERELEASE" != "null" ]; then
-                PRERELEASE_INFO="${PRERELEASE_INFO}• \\\`${repo}\\\` has pre-release: ${LATEST_PRERELEASE}\n"
                 echo "  Found pre-release: ${LATEST_PRERELEASE}"
+                echo "  Latest release: ${LATEST_RELEASE:-none}"
+                
+                # Only include pre-release if it's newer than the latest release
+                if compare_versions "$LATEST_PRERELEASE" "$LATEST_RELEASE"; then
+                  PRERELEASE_INFO="${PRERELEASE_INFO}| **${repo}** | ${LATEST_PRERELEASE} | ${LATEST_RELEASE:-N/A} | 🆕 |\n"
+                  echo "  Pre-release ${LATEST_PRERELEASE} is newer than release ${LATEST_RELEASE}"
+                else
+                  echo "  Pre-release ${LATEST_PRERELEASE} is not newer than release ${LATEST_RELEASE}, skipping"
+                fi
               else
                 echo "  No pre-release found"
               fi
@@ -209,53 +261,53 @@ jobs:
           done
           
           if [ -z "$PRERELEASE_INFO" ]; then
-            echo "PRERELEASE_STATUS=No pre-releases found for today's scheduled repos" >> $GITHUB_OUTPUT
+            echo "PRERELEASE_STATUS=No new pre-releases ready for promotion" >> $GITHUB_OUTPUT
+            echo "HAS_PRERELEASES=false" >> $GITHUB_OUTPUT
           else
+            # Add table header
+            TABLE_HEADER="| Repository | Pre-release | Latest Release | Status |\n"
+            TABLE_HEADER="${TABLE_HEADER}|------------|-------------|----------------|--------|\n"
+            
             echo "PRERELEASE_STATUS<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$PRERELEASE_INFO" >> $GITHUB_OUTPUT
+            echo -e "${TABLE_HEADER}${PRERELEASE_INFO}" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+            echo "HAS_PRERELEASES=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Format Slack message
         id: format_message
         run: |
-          # Build the complete Slack message (escape backticks properly)
-          MESSAGE="# 📅 Daily Release Status Report - ${{ steps.get_day.outputs.DAY_NAME }}"
-          MESSAGE="${MESSAGE}\n\n"
-          MESSAGE="${MESSAGE}${{ steps.check_status.outputs.STATUS_MESSAGE }}"
-          MESSAGE="${MESSAGE}\n\n"
+          # Create a properly formatted Slack message using printf to avoid backtick issues
           
-          if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
-            MESSAGE="${MESSAGE}## 🚀 Scheduled Releases for Today:"
-            MESSAGE="${MESSAGE}\n"
-            # The RELEASES output already has escaped backticks
-            RELEASES_CONTENT=$(echo -e "${{ steps.get_releases.outputs.RELEASES }}")
-            MESSAGE="${MESSAGE}${RELEASES_CONTENT}"
-            MESSAGE="${MESSAGE}\n"
+          # Start building the message
+          {
+            printf "# 📅 Daily Release Status Report - %s\n\n" "${{ steps.get_day.outputs.DAY_NAME }}"
+            printf "%s\n\n" "${{ steps.check_status.outputs.STATUS_MESSAGE }}"
             
-            if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ] && [ "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" != "No pre-releases found for today's scheduled repos" ]; then
-              MESSAGE="${MESSAGE}## 📦 Pre-release Status:"
-              MESSAGE="${MESSAGE}\n"
-              PRERELEASE_CONTENT=$(echo -e "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}")
-              MESSAGE="${MESSAGE}${PRERELEASE_CONTENT}"
-              MESSAGE="${MESSAGE}\n"
+            if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
+              printf "## 🚀 Scheduled Releases for Today:\n"
+              printf "%s\n" "${{ steps.get_releases.outputs.RELEASES }}"
+              
+              if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ] && [ "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" != "No pre-releases found for today's scheduled repos" ]; then
+                printf "## 📦 Pre-release Status:\n"
+                printf "%s\n" "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}"
+              fi
+            else
+              printf "## 📋 Scheduled Releases:\n"
+              printf "%s\n" "${{ steps.get_releases.outputs.RELEASES }}"
             fi
-          else
-            MESSAGE="${MESSAGE}## 📋 Scheduled Releases:"
-            MESSAGE="${MESSAGE}\n"
-            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}"
-            MESSAGE="${MESSAGE}\n"
-          fi
+            
+            printf "\n---\n"
+            printf "_Generated by [Workflow Run #%s](%s/%s/actions/runs/%s)_" \
+              "${{ github.run_number }}" \
+              "${{ github.server_url }}" \
+              "${{ github.repository }}" \
+              "${{ github.run_id }}"
+          } > slack_message.txt
           
-          # Add workflow run link
-          MESSAGE="${MESSAGE}\n---\n"
-          MESSAGE="${MESSAGE}_Generated by [Workflow Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
-          
-          # Save formatted message (properly escaped)
-          cat << 'SLACK_EOF' >> $GITHUB_OUTPUT
-          SLACK_MESSAGE<<EOF
-          SLACK_EOF
-          echo -e "$MESSAGE" >> $GITHUB_OUTPUT
+          # Read the message and save to output
+          echo "SLACK_MESSAGE<<EOF" >> $GITHUB_OUTPUT
+          cat slack_message.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -42,10 +42,10 @@ jobs:
         run: |
           if [ -f "${{ env.UNBLOCK_FILE_NAME }}" ]; then
             echo "RELEASES_ENABLED=true" >> $GITHUB_OUTPUT
-            echo "STATUS_MESSAGE=✅ **Automatic releases are ENABLED**" >> $GITHUB_OUTPUT
+            echo "STATUS_MESSAGE=:white_check_mark: *Automatic releases are ENABLED*" >> $GITHUB_OUTPUT
           else
             echo "RELEASES_ENABLED=false" >> $GITHUB_OUTPUT
-            echo "STATUS_MESSAGE=🚫 **Automatic releases are BLOCKED**" >> $GITHUB_OUTPUT
+            echo "STATUS_MESSAGE=:no_entry_sign: *Automatic releases are BLOCKED*" >> $GITHUB_OUTPUT
           fi
           
       - name: Determine day to check
@@ -118,18 +118,16 @@ jobs:
             ["nri-jmx"]="19:00 UTC (00:30 IST next day)|Package"
           )
           
-          # Build release list based on day - in table format
-          RELEASE_TABLE="| Repository | Schedule (UTC) | Schedule (IST) | Type |\n"
-          RELEASE_TABLE="${RELEASE_TABLE}|------------|----------------|----------------|------|\n"
+          # Build release list for Slack formatting with proper spacing
+          RELEASE_LIST=""
           
           case $DAY_NUM in
             1)
               for repo in "${!MONDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${MONDAY_RELEASES[$repo]}"
-                # Split UTC and IST times
                 UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
                 IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
-                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
+                RELEASE_LIST="${RELEASE_LIST}• *${repo}* - ${UTC_TIME} (${IST_TIME}) - ${type}\n"
               done
               ;;
             2)
@@ -137,7 +135,7 @@ jobs:
                 IFS='|' read -r time type <<< "${TUESDAY_RELEASES[$repo]}"
                 UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
                 IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
-                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
+                RELEASE_LIST="${RELEASE_LIST}• *${repo}* - ${UTC_TIME} (${IST_TIME}) - ${type}\n"
               done
               ;;
             3)
@@ -145,7 +143,7 @@ jobs:
                 IFS='|' read -r time type <<< "${WEDNESDAY_RELEASES[$repo]}"
                 UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
                 IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
-                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
+                RELEASE_LIST="${RELEASE_LIST}• *${repo}* - ${UTC_TIME} (${IST_TIME}) - ${type}\n"
               done
               ;;
             4)
@@ -153,25 +151,24 @@ jobs:
                 IFS='|' read -r time type <<< "${THURSDAY_RELEASES[$repo]}"
                 UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
                 IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
-                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
+                RELEASE_LIST="${RELEASE_LIST}• *${repo}* - ${UTC_TIME} (${IST_TIME}) - ${type}\n"
               done
               ;;
             5)
-              RELEASE_TABLE="No scheduled releases on Friday 😴"
+              RELEASE_LIST="No scheduled releases on Friday :sleeping:"
               ;;
             *)
-              RELEASE_TABLE="No scheduled releases for this day"
+              RELEASE_LIST="No scheduled releases for this day"
               ;;
           esac
           
-          # Save to output (escape newlines for GitHub Actions)
-          if [[ "$RELEASE_TABLE" == "No scheduled releases"* ]]; then
-            echo "RELEASES=$RELEASE_TABLE" >> $GITHUB_OUTPUT
+          # Save to output
+          if [[ "$RELEASE_LIST" == "No scheduled releases"* ]]; then
+            echo "RELEASES=$RELEASE_LIST" >> $GITHUB_OUTPUT
             echo "HAS_RELEASES=false" >> $GITHUB_OUTPUT
           else
-            # Escape the release list for multi-line output
             echo "RELEASES<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$RELEASE_TABLE" >> $GITHUB_OUTPUT
+            echo -e "$RELEASE_LIST" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
             echo "HAS_RELEASES=true" >> $GITHUB_OUTPUT
           fi
@@ -258,7 +255,7 @@ jobs:
                 
                 # Only include pre-release if it's newer than the latest release
                 if compare_versions "$LATEST_PRERELEASE" "$LATEST_RELEASE"; then
-                  PRERELEASE_INFO="${PRERELEASE_INFO}| **${repo}** | ${LATEST_PRERELEASE} | ${LATEST_RELEASE:-N/A} | 🆕 |\n"
+                  PRERELEASE_INFO="${PRERELEASE_INFO}• *${repo}* - Pre-release: \`${LATEST_PRERELEASE}\` | Latest: \`${LATEST_RELEASE:-N/A}\` :arrow_up:\n"
                   echo "  Pre-release ${LATEST_PRERELEASE} is newer than release ${LATEST_RELEASE}"
                 else
                   echo "  Pre-release ${LATEST_PRERELEASE} is not newer than release ${LATEST_RELEASE}, skipping"
@@ -275,12 +272,8 @@ jobs:
             echo "PRERELEASE_STATUS=No new pre-releases ready for promotion" >> $GITHUB_OUTPUT
             echo "HAS_PRERELEASES=false" >> $GITHUB_OUTPUT
           else
-            # Add table header
-            TABLE_HEADER="| Repository | Pre-release | Latest Release | Status |\n"
-            TABLE_HEADER="${TABLE_HEADER}|------------|-------------|----------------|--------|\n"
-            
             echo "PRERELEASE_STATUS<<EOF" >> $GITHUB_OUTPUT
-            echo -e "${TABLE_HEADER}${PRERELEASE_INFO}" >> $GITHUB_OUTPUT
+            echo -e "$PRERELEASE_INFO" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
             echo "HAS_PRERELEASES=true" >> $GITHUB_OUTPUT
           fi
@@ -288,87 +281,72 @@ jobs:
       - name: Format Slack message
         id: format_message
         run: |
-          # Create a properly formatted Slack message with emojis and tables
-          
-          # Determine status emoji
-          if [ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ]; then
-            STATUS_EMOJI="✅"
-            STATUS_TEXT="ENABLED"
-          else
-            STATUS_EMOJI="🚫"
-            STATUS_TEXT="BLOCKED"
-          fi
+          # Create a properly formatted Slack message with proper Slack markup
+          CURRENT_TIME=$(date -u '+%H:%M')
           
           # Start building the message
-          cat > slack_message.txt << 'MESSAGE_END'
-          # 📅 Daily Release Status Report
-          ## 🗓️ ${{ steps.get_day.outputs.DAY_NAME }} | ⏰ Generated at $(date -u '+%H:%M') UTC
-          
-          ---
-          
-          ### 🚦 Automatic Release Status
+          cat > slack_message.txt << MESSAGE_END
+          :calendar: *Daily Release Status Report*
+          :clock1: ${{ steps.get_day.outputs.DAY_NAME }} | Generated at ${CURRENT_TIME} UTC
+
+          ────────────────────────────────────
+
+          :traffic_light: *Automatic Release Status*
           ${{ steps.check_status.outputs.STATUS_MESSAGE }}
-          
+
           MESSAGE_END
           
           # Add scheduled releases section
           if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
             cat >> slack_message.txt << 'MESSAGE_END'
-          ### 🚀 Today's Scheduled Releases
-          
+          :rocket: *Today's Scheduled Releases*
+
           ${{ steps.get_releases.outputs.RELEASES }}
-          
+
           MESSAGE_END
             
             # Add pre-release section if there are any
             if [ "${{ steps.check_prereleases.outputs.HAS_PRERELEASES }}" == "true" ]; then
               cat >> slack_message.txt << 'MESSAGE_END'
-          ### 📦 Pre-releases Ready for Promotion
-          🎯 The following pre-releases are newer than their latest releases and will be promoted:
-          
+          :package: *Pre-releases Ready for Promotion*
+          :dart: The following pre-releases are newer than their latest releases and will be promoted:
+
           ${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}
-          
+
           MESSAGE_END
             else
               cat >> slack_message.txt << 'MESSAGE_END'
-          ### 📦 Pre-release Status
-          ℹ️ No new pre-releases ready for promotion today.
-          
+          :package: *Pre-release Status*
+          :information_source: No new pre-releases ready for promotion today.
+
           MESSAGE_END
             fi
             
             # Add summary stats
-            REPO_COUNT=$(echo "${{ steps.get_releases.outputs.RELEASES }}" | grep -c "| \*\*" || echo "0")
-            PRERELEASE_COUNT=$(echo "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" | grep -c "🆕" || echo "0")
+            REPO_COUNT=$(echo "${{ steps.get_releases.outputs.RELEASES }}" | grep -c "^•" || echo "0")
+            PRERELEASE_COUNT=$(echo "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" | grep -c ":arrow_up:" || echo "0")
             
             {
-              echo "### 📊 Summary"
-              echo "• 📅 **Total scheduled releases:** $REPO_COUNT"
-              echo "• 🆕 **Pre-releases to promote:** $PRERELEASE_COUNT"
+              echo ":bar_chart: *Summary*"
+              echo "• :calendar: *Total scheduled releases:* $REPO_COUNT"
+              echo "• :new: *Pre-releases to promote:* $PRERELEASE_COUNT"
               
               if [ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ]; then
-                echo "• ✅ **Status:** Ready to release! 🎉"
+                echo "• :white_check_mark: *Status:* Ready to release! :tada:"
               else
-                echo "• ⚠️ **Status:** Releases blocked - manual intervention required"
+                echo "• :warning: *Status:* Releases blocked - manual intervention required"
               fi
               echo ""
             } >> slack_message.txt
           else
             cat >> slack_message.txt << 'MESSAGE_END'
-          ### 📋 Release Schedule
-          😴 ${{ steps.get_releases.outputs.RELEASES }}
-          
+          :clipboard: *Release Schedule*
+          :sleeping: ${{ steps.get_releases.outputs.RELEASES }}
+
           MESSAGE_END
           fi
           
-          # Add footer
-          cat >> slack_message.txt << MESSAGE_END
-          ---
-          _🤖 Generated by [Workflow Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_
-          _💡 To $([ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ] && echo "disable" || echo "enable") automatic releases, trigger the appropriate workflow_
-          MESSAGE_END
-          
-          # Save to GitHub output
+          # Save to GitHub output (no footer with workflow link)
           {
             echo "SLACK_MESSAGE<<EOF"
             cat slack_message.txt
@@ -376,12 +354,17 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
-        uses: archive/github-actions-slack@master
+        uses: 8398a7/action-slack@v3
         with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: |
-            ${{ steps.format_message.outputs.SLACK_MESSAGE }}
+          status: custom
+          custom_payload: |
+            {
+              "text": "${{ steps.format_message.outputs.SLACK_MESSAGE }}",
+              "username": "Release Bot",
+              "icon_emoji": ":rocket:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.COREINT_SLACK_WEBHOOK_URL }}
 
       - name: Summary
         run: |

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -354,17 +354,12 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
-        uses: 8398a7/action-slack@v3
+        uses: archive/github-actions-slack@master
         with:
-          status: custom
-          custom_payload: |
-            {
-              "text": "${{ steps.format_message.outputs.SLACK_MESSAGE }}",
-              "username": "Release Bot",
-              "icon_emoji": ":rocket:"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.COREINT_SLACK_WEBHOOK_URL }}
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: ${{ steps.format_message.outputs.SLACK_MESSAGE }}
+          slack-optional-parse: full
 
       - name: Summary
         run: |

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -1,0 +1,258 @@
+name: Daily Release Status Notification
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      specific_day:
+        description: 'Check releases for a specific day (1=Monday, 2=Tuesday, etc.)'
+        required: false
+        type: choice
+        options:
+          - 'today'
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+        default: 'today'
+
+env:
+  UNBLOCK_FILE_NAME: automatic_release_enable
+  BRANCH: gh-pages
+
+jobs:
+  check-and-notify:
+    name: Check Release Status and Send Notification
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH }}
+          
+      - name: Check if automatic releases are enabled
+        id: check_status
+        run: |
+          if [ -f "${{ env.UNBLOCK_FILE_NAME }}" ]; then
+            echo "RELEASES_ENABLED=true" >> $GITHUB_OUTPUT
+            echo "STATUS_MESSAGE=✅ **Automatic releases are ENABLED**" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASES_ENABLED=false" >> $GITHUB_OUTPUT
+            echo "STATUS_MESSAGE=🚫 **Automatic releases are BLOCKED**" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Determine day to check
+        id: get_day
+        run: |
+          if [ "${{ github.event.inputs.specific_day }}" == "today" ] || [ -z "${{ github.event.inputs.specific_day }}" ]; then
+            # Get current day of week (1=Monday, 2=Tuesday, etc.)
+            DAY_NUM=$(date +%u)
+          else
+            DAY_NUM="${{ github.event.inputs.specific_day }}"
+          fi
+          
+          echo "DAY_NUMBER=$DAY_NUM" >> $GITHUB_OUTPUT
+          
+          # Map day number to day name
+          case $DAY_NUM in
+            1) DAY_NAME="Monday" ;;
+            2) DAY_NAME="Tuesday" ;;
+            3) DAY_NAME="Wednesday" ;;
+            4) DAY_NAME="Thursday" ;;
+            5) DAY_NAME="Friday" ;;
+            *) DAY_NAME="Invalid Day" ;;
+          esac
+          
+          echo "DAY_NAME=$DAY_NAME" >> $GITHUB_OUTPUT
+          
+      - name: Get scheduled releases for today
+        id: get_releases
+        run: |
+          DAY_NUM="${{ steps.get_day.outputs.DAY_NUMBER }}"
+          
+          # Define all integrations with their schedules
+          declare -A MONDAY_RELEASES=(
+            ["nri-consul"]="02:00 UTC|Package"
+            ["nri-mysql"]="05:30 UTC|Package"
+            ["nri-memcached"]="07:30 UTC|Package"
+            ["nri-redis"]="09:30 UTC|Package"
+            ["nri-varnish"]="11:30 UTC|Package"
+            ["nri-discovery"]="13:00 UTC|GITHUB BINARY"
+            ["nri-apache"]="13:00 UTC|Package"
+            ["nri-postgresql"]="15:00 UTC|Package"
+          )
+          
+          declare -A TUESDAY_RELEASES=(
+            ["nri-haproxy"]="02:00 UTC|Package"
+            ["nri-nagios"]="03:30 UTC|Package"
+            ["nri-elasticsearch"]="05:30 UTC|Package"
+            ["nri-mongodb"]="07:30 UTC|Package"
+            ["nri-mssql"]="09:30 UTC|Package"
+            ["nri-oracledb"]="13:00 UTC|Package"
+            ["nri-docker"]="15:00 UTC|PACKAGE"
+          )
+          
+          declare -A WEDNESDAY_RELEASES=(
+            ["nri-couchbase"]="02:30 UTC|PACKAGE"
+            ["nri-rabbitmq"]="05:30 UTC|PACKAGE"
+            ["nri-kafka"]="10:30 UTC|Package"
+            ["nri-prometheus"]="12:00 UTC|IMAGE"
+            ["nri-cassandra"]="13:30 UTC|Package"
+            ["nri-nginx"]="17:00 UTC|Package"
+            ["nrjmx"]="19:00 UTC|Package"
+          )
+          
+          declare -A THURSDAY_RELEASES=(
+            ["nri-f5"]="05:00 UTC|Package"
+            ["nri-vsphere"]="09:00 UTC|Package"
+            ["infrastructure-bundle"]="10:00 UTC|IMAGE"
+            ["nri-ecs"]="15:00 UTC|Image"
+            ["nri-statsd"]="17:00 UTC|Image"
+            ["nri-jmx"]="19:00 UTC|Package"
+          )
+          
+          # Build release list based on day
+          RELEASE_LIST=""
+          case $DAY_NUM in
+            1)
+              for repo in "${!MONDAY_RELEASES[@]}"; do
+                IFS='|' read -r time type <<< "${MONDAY_RELEASES[$repo]}"
+                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+              done
+              ;;
+            2)
+              for repo in "${!TUESDAY_RELEASES[@]}"; do
+                IFS='|' read -r time type <<< "${TUESDAY_RELEASES[$repo]}"
+                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+              done
+              ;;
+            3)
+              for repo in "${!WEDNESDAY_RELEASES[@]}"; do
+                IFS='|' read -r time type <<< "${WEDNESDAY_RELEASES[$repo]}"
+                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+              done
+              ;;
+            4)
+              for repo in "${!THURSDAY_RELEASES[@]}"; do
+                IFS='|' read -r time type <<< "${THURSDAY_RELEASES[$repo]}"
+                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+              done
+              ;;
+            5)
+              RELEASE_LIST="No scheduled releases on Friday"
+              ;;
+            *)
+              RELEASE_LIST="No scheduled releases for this day"
+              ;;
+          esac
+          
+          # Save to output (escape newlines for GitHub Actions)
+          if [ -z "$RELEASE_LIST" ] || [ "$RELEASE_LIST" == "No scheduled releases"* ]; then
+            echo "RELEASES=$RELEASE_LIST" >> $GITHUB_OUTPUT
+            echo "HAS_RELEASES=false" >> $GITHUB_OUTPUT
+          else
+            # Escape the release list for multi-line output
+            echo "RELEASES<<EOF" >> $GITHUB_OUTPUT
+            echo -e "$RELEASE_LIST" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "HAS_RELEASES=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for pre-releases in scheduled repos
+        id: check_prereleases
+        if: steps.get_releases.outputs.HAS_RELEASES == 'true'
+        run: |
+          # This step would check each scheduled repo for existing pre-releases
+          # For now, we'll create a placeholder that can be expanded
+          
+          PRERELEASE_INFO=""
+          DAY_NUM="${{ steps.get_day.outputs.DAY_NUMBER }}"
+          
+          # Get list of repos for today (simplified version)
+          case $DAY_NUM in
+            1) REPOS="nri-consul nri-mysql nri-memcached nri-redis nri-varnish nri-discovery nri-apache nri-postgresql" ;;
+            2) REPOS="nri-haproxy nri-nagios nri-elasticsearch nri-mongodb nri-mssql nri-oracledb nri-docker" ;;
+            3) REPOS="nri-couchbase nri-rabbitmq nri-kafka nri-prometheus nri-cassandra nri-nginx nrjmx" ;;
+            4) REPOS="nri-f5 nri-vsphere infrastructure-bundle nri-ecs nri-statsd nri-jmx" ;;
+            *) REPOS="" ;;
+          esac
+          
+          # Check for pre-releases in each repo
+          for repo in $REPOS; do
+            # Using GitHub API to check for pre-releases
+            # Note: This requires GITHUB_TOKEN to have appropriate permissions
+            LATEST_PRERELEASE=$(curl -s \
+              -H "Authorization: token ${{ github.token }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository_owner }}/${repo}/releases" \
+              | jq -r '.[] | select(.prerelease==true) | .tag_name' | head -1)
+            
+            if [ -n "$LATEST_PRERELEASE" ]; then
+              PRERELEASE_INFO="${PRERELEASE_INFO}• \`${repo}\` has pre-release: ${LATEST_PRERELEASE}\n"
+            fi
+          done
+          
+          if [ -z "$PRERELEASE_INFO" ]; then
+            echo "PRERELEASE_STATUS=No pre-releases found for today's scheduled repos" >> $GITHUB_OUTPUT
+          else
+            echo "PRERELEASE_STATUS<<EOF" >> $GITHUB_OUTPUT
+            echo -e "$PRERELEASE_INFO" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Format Slack message
+        id: format_message
+        run: |
+          # Build the complete Slack message
+          MESSAGE="# 📅 Daily Release Status Report - ${{ steps.get_day.outputs.DAY_NAME }}\n\n"
+          MESSAGE="${MESSAGE}${{ steps.check_status.outputs.STATUS_MESSAGE }}\n\n"
+          
+          if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
+            MESSAGE="${MESSAGE}## 🚀 Scheduled Releases for Today:\n"
+            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}\n"
+            
+            if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ]; then
+              MESSAGE="${MESSAGE}## 📦 Pre-release Status:\n"
+              MESSAGE="${MESSAGE}${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}\n"
+            fi
+          else
+            MESSAGE="${MESSAGE}## 📋 Scheduled Releases:\n"
+            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}\n"
+          fi
+          
+          # Add workflow run link
+          MESSAGE="${MESSAGE}\n---\n"
+          MESSAGE="${MESSAGE}_Generated by [Workflow Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+          
+          # Save formatted message
+          echo "SLACK_MESSAGE<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$MESSAGE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: |
+            ${{ steps.format_message.outputs.SLACK_MESSAGE }}
+
+      - name: Summary
+        run: |
+          echo "## Release Status Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Day:** ${{ steps.get_day.outputs.DAY_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Automatic Releases:** ${{ steps.check_status.outputs.RELEASES_ENABLED == 'true' && 'Enabled ✅' || 'Blocked 🚫' }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
+            echo "### Scheduled Releases:" >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.get_releases.outputs.RELEASES }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### No releases scheduled for today" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
-  pull_request:
-    branches: [ main ]
-
   workflow_dispatch:
     inputs:
       specific_day:

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
+  pull_request:
+    branches: [ main ]
+
   workflow_dispatch:
     inputs:
       specific_day:

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -77,45 +77,45 @@ jobs:
         run: |
           DAY_NUM="${{ steps.get_day.outputs.DAY_NUMBER }}"
           
-          # Define all integrations with their schedules
+          # Define all integrations with their schedules (UTC and IST)
           declare -A MONDAY_RELEASES=(
-            ["nri-consul"]="02:00 UTC|Package"
-            ["nri-mysql"]="05:30 UTC|Package"
-            ["nri-memcached"]="07:30 UTC|Package"
-            ["nri-redis"]="09:30 UTC|Package"
-            ["nri-varnish"]="11:30 UTC|Package"
-            ["nri-discovery"]="13:00 UTC|GITHUB BINARY"
-            ["nri-apache"]="13:00 UTC|Package"
-            ["nri-postgresql"]="15:00 UTC|Package"
+            ["nri-consul"]="02:00 UTC (07:30 IST)|Package"
+            ["nri-mysql"]="05:30 UTC (11:00 IST)|Package"
+            ["nri-memcached"]="07:30 UTC (13:00 IST)|Package"
+            ["nri-redis"]="09:30 UTC (15:00 IST)|Package"
+            ["nri-varnish"]="11:30 UTC (17:00 IST)|Package"
+            ["nri-discovery"]="13:00 UTC (18:30 IST)|GITHUB BINARY"
+            ["nri-apache"]="13:00 UTC (18:30 IST)|Package"
+            ["nri-postgresql"]="15:00 UTC (20:30 IST)|Package"
           )
           
           declare -A TUESDAY_RELEASES=(
-            ["nri-haproxy"]="02:00 UTC|Package"
-            ["nri-nagios"]="03:30 UTC|Package"
-            ["nri-elasticsearch"]="05:30 UTC|Package"
-            ["nri-mongodb"]="07:30 UTC|Package"
-            ["nri-mssql"]="09:30 UTC|Package"
-            ["nri-oracledb"]="13:00 UTC|Package"
-            ["nri-docker"]="15:00 UTC|PACKAGE"
+            ["nri-haproxy"]="02:00 UTC (07:30 IST)|Package"
+            ["nri-nagios"]="03:30 UTC (09:00 IST)|Package"
+            ["nri-elasticsearch"]="05:30 UTC (11:00 IST)|Package"
+            ["nri-mongodb"]="07:30 UTC (13:00 IST)|Package"
+            ["nri-mssql"]="09:30 UTC (15:00 IST)|Package"
+            ["nri-oracledb"]="13:00 UTC (18:30 IST)|Package"
+            ["nri-docker"]="15:00 UTC (20:30 IST)|PACKAGE"
           )
           
           declare -A WEDNESDAY_RELEASES=(
-            ["nri-couchbase"]="02:30 UTC|PACKAGE"
-            ["nri-rabbitmq"]="05:30 UTC|PACKAGE"
-            ["nri-kafka"]="10:30 UTC|Package"
-            ["nri-prometheus"]="12:00 UTC|IMAGE"
-            ["nri-cassandra"]="13:30 UTC|Package"
-            ["nri-nginx"]="17:00 UTC|Package"
-            ["nrjmx"]="19:00 UTC|Package"
+            ["nri-couchbase"]="02:30 UTC (08:00 IST)|PACKAGE"
+            ["nri-rabbitmq"]="05:30 UTC (11:00 IST)|PACKAGE"
+            ["nri-kafka"]="10:30 UTC (16:00 IST)|Package"
+            ["nri-prometheus"]="12:00 UTC (17:30 IST)|IMAGE"
+            ["nri-cassandra"]="13:30 UTC (19:00 IST)|Package"
+            ["nri-nginx"]="17:00 UTC (22:30 IST)|Package"
+            ["nrjmx"]="19:00 UTC (00:30 IST next day)|Package"
           )
           
           declare -A THURSDAY_RELEASES=(
-            ["nri-f5"]="05:00 UTC|Package"
-            ["nri-vsphere"]="09:00 UTC|Package"
-            ["infrastructure-bundle"]="10:00 UTC|IMAGE"
-            ["nri-ecs"]="15:00 UTC|Image"
-            ["nri-statsd"]="17:00 UTC|Image"
-            ["nri-jmx"]="19:00 UTC|Package"
+            ["nri-f5"]="05:00 UTC (10:30 IST)|Package"
+            ["nri-vsphere"]="09:00 UTC (14:30 IST)|Package"
+            ["infrastructure-bundle"]="10:00 UTC (15:30 IST)|IMAGE"
+            ["nri-ecs"]="15:00 UTC (20:30 IST)|Image"
+            ["nri-statsd"]="17:00 UTC (22:30 IST)|Image"
+            ["nri-jmx"]="19:00 UTC (00:30 IST next day)|Package"
           )
           
           # Build release list based on day
@@ -124,25 +124,25 @@ jobs:
             1)
               for repo in "${!MONDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${MONDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
               done
               ;;
             2)
               for repo in "${!TUESDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${TUESDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
               done
               ;;
             3)
               for repo in "${!WEDNESDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${WEDNESDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
               done
               ;;
             4)
               for repo in "${!THURSDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${THURSDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• \`${repo}\` - ${time} (${type})\n"
+                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
               done
               ;;
             5)
@@ -168,14 +168,13 @@ jobs:
       - name: Check for pre-releases in scheduled repos
         id: check_prereleases
         if: steps.get_releases.outputs.HAS_RELEASES == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # This step would check each scheduled repo for existing pre-releases
-          # For now, we'll create a placeholder that can be expanded
-          
           PRERELEASE_INFO=""
           DAY_NUM="${{ steps.get_day.outputs.DAY_NUMBER }}"
           
-          # Get list of repos for today (simplified version)
+          # Get list of repos for today
           case $DAY_NUM in
             1) REPOS="nri-consul nri-mysql nri-memcached nri-redis nri-varnish nri-discovery nri-apache nri-postgresql" ;;
             2) REPOS="nri-haproxy nri-nagios nri-elasticsearch nri-mongodb nri-mssql nri-oracledb nri-docker" ;;
@@ -186,16 +185,26 @@ jobs:
           
           # Check for pre-releases in each repo
           for repo in $REPOS; do
-            # Using GitHub API to check for pre-releases
-            # Note: This requires GITHUB_TOKEN to have appropriate permissions
-            LATEST_PRERELEASE=$(curl -s \
-              -H "Authorization: token ${{ github.token }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository_owner }}/${repo}/releases" \
-              | jq -r '.[] | select(.prerelease==true) | .tag_name' | head -1)
+            echo "Checking releases for newrelic/${repo}..."
             
-            if [ -n "$LATEST_PRERELEASE" ]; then
-              PRERELEASE_INFO="${PRERELEASE_INFO}• \`${repo}\` has pre-release: ${LATEST_PRERELEASE}\n"
+            # Using GitHub API to check for pre-releases
+            RESPONSE=$(curl -s \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/newrelic/${repo}/releases")
+            
+            # Check if we got a valid response
+            if echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+              LATEST_PRERELEASE=$(echo "$RESPONSE" | jq -r '.[] | select(.prerelease==true) | .tag_name' | head -1)
+              
+              if [ -n "$LATEST_PRERELEASE" ] && [ "$LATEST_PRERELEASE" != "null" ]; then
+                PRERELEASE_INFO="${PRERELEASE_INFO}• \\\`${repo}\\\` has pre-release: ${LATEST_PRERELEASE}\n"
+                echo "  Found pre-release: ${LATEST_PRERELEASE}"
+              else
+                echo "  No pre-release found"
+              fi
+            else
+              echo "  Unable to fetch releases (repo might not exist or access denied)"
             fi
           done
           
@@ -210,29 +219,42 @@ jobs:
       - name: Format Slack message
         id: format_message
         run: |
-          # Build the complete Slack message
-          MESSAGE="# 📅 Daily Release Status Report - ${{ steps.get_day.outputs.DAY_NAME }}\n\n"
-          MESSAGE="${MESSAGE}${{ steps.check_status.outputs.STATUS_MESSAGE }}\n\n"
+          # Build the complete Slack message (escape backticks properly)
+          MESSAGE="# 📅 Daily Release Status Report - ${{ steps.get_day.outputs.DAY_NAME }}"
+          MESSAGE="${MESSAGE}\n\n"
+          MESSAGE="${MESSAGE}${{ steps.check_status.outputs.STATUS_MESSAGE }}"
+          MESSAGE="${MESSAGE}\n\n"
           
           if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
-            MESSAGE="${MESSAGE}## 🚀 Scheduled Releases for Today:\n"
-            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}\n"
+            MESSAGE="${MESSAGE}## 🚀 Scheduled Releases for Today:"
+            MESSAGE="${MESSAGE}\n"
+            # The RELEASES output already has escaped backticks
+            RELEASES_CONTENT=$(echo -e "${{ steps.get_releases.outputs.RELEASES }}")
+            MESSAGE="${MESSAGE}${RELEASES_CONTENT}"
+            MESSAGE="${MESSAGE}\n"
             
-            if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ]; then
-              MESSAGE="${MESSAGE}## 📦 Pre-release Status:\n"
-              MESSAGE="${MESSAGE}${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}\n"
+            if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ] && [ "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" != "No pre-releases found for today's scheduled repos" ]; then
+              MESSAGE="${MESSAGE}## 📦 Pre-release Status:"
+              MESSAGE="${MESSAGE}\n"
+              PRERELEASE_CONTENT=$(echo -e "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}")
+              MESSAGE="${MESSAGE}${PRERELEASE_CONTENT}"
+              MESSAGE="${MESSAGE}\n"
             fi
           else
-            MESSAGE="${MESSAGE}## 📋 Scheduled Releases:\n"
-            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}\n"
+            MESSAGE="${MESSAGE}## 📋 Scheduled Releases:"
+            MESSAGE="${MESSAGE}\n"
+            MESSAGE="${MESSAGE}${{ steps.get_releases.outputs.RELEASES }}"
+            MESSAGE="${MESSAGE}\n"
           fi
           
           # Add workflow run link
           MESSAGE="${MESSAGE}\n---\n"
           MESSAGE="${MESSAGE}_Generated by [Workflow Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
           
-          # Save formatted message
-          echo "SLACK_MESSAGE<<EOF" >> $GITHUB_OUTPUT
+          # Save formatted message (properly escaped)
+          cat << 'SLACK_EOF' >> $GITHUB_OUTPUT
+          SLACK_MESSAGE<<EOF
+          SLACK_EOF
           echo -e "$MESSAGE" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       specific_day:

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       specific_day:

--- a/.github/workflows/daily_releases.yml
+++ b/.github/workflows/daily_releases.yml
@@ -118,49 +118,60 @@ jobs:
             ["nri-jmx"]="19:00 UTC (00:30 IST next day)|Package"
           )
           
-          # Build release list based on day
-          RELEASE_LIST=""
+          # Build release list based on day - in table format
+          RELEASE_TABLE="| Repository | Schedule (UTC) | Schedule (IST) | Type |\n"
+          RELEASE_TABLE="${RELEASE_TABLE}|------------|----------------|----------------|------|\n"
+          
           case $DAY_NUM in
             1)
               for repo in "${!MONDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${MONDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
+                # Split UTC and IST times
+                UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
+                IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
+                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
               done
               ;;
             2)
               for repo in "${!TUESDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${TUESDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
+                UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
+                IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
+                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
               done
               ;;
             3)
               for repo in "${!WEDNESDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${WEDNESDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
+                UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
+                IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
+                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
               done
               ;;
             4)
               for repo in "${!THURSDAY_RELEASES[@]}"; do
                 IFS='|' read -r time type <<< "${THURSDAY_RELEASES[$repo]}"
-                RELEASE_LIST="${RELEASE_LIST}• **${repo}** - ${time} (${type})\n"
+                UTC_TIME=$(echo "$time" | sed -n 's/\(.*\) UTC.*/\1 UTC/p')
+                IST_TIME=$(echo "$time" | sed -n 's/.*(\(.*\)).*/\1/p')
+                RELEASE_TABLE="${RELEASE_TABLE}| **${repo}** | ${UTC_TIME} | ${IST_TIME} | ${type} |\n"
               done
               ;;
             5)
-              RELEASE_LIST="No scheduled releases on Friday"
+              RELEASE_TABLE="No scheduled releases on Friday 😴"
               ;;
             *)
-              RELEASE_LIST="No scheduled releases for this day"
+              RELEASE_TABLE="No scheduled releases for this day"
               ;;
           esac
           
           # Save to output (escape newlines for GitHub Actions)
-          if [ -z "$RELEASE_LIST" ] || [ "$RELEASE_LIST" == "No scheduled releases"* ]; then
-            echo "RELEASES=$RELEASE_LIST" >> $GITHUB_OUTPUT
+          if [[ "$RELEASE_TABLE" == "No scheduled releases"* ]]; then
+            echo "RELEASES=$RELEASE_TABLE" >> $GITHUB_OUTPUT
             echo "HAS_RELEASES=false" >> $GITHUB_OUTPUT
           else
             # Escape the release list for multi-line output
             echo "RELEASES<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$RELEASE_LIST" >> $GITHUB_OUTPUT
+            echo -e "$RELEASE_TABLE" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
             echo "HAS_RELEASES=true" >> $GITHUB_OUTPUT
           fi
@@ -277,38 +288,92 @@ jobs:
       - name: Format Slack message
         id: format_message
         run: |
-          # Create a properly formatted Slack message using printf to avoid backtick issues
+          # Create a properly formatted Slack message with emojis and tables
+          
+          # Determine status emoji
+          if [ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ]; then
+            STATUS_EMOJI="✅"
+            STATUS_TEXT="ENABLED"
+          else
+            STATUS_EMOJI="🚫"
+            STATUS_TEXT="BLOCKED"
+          fi
           
           # Start building the message
-          {
-            printf "# 📅 Daily Release Status Report - %s\n\n" "${{ steps.get_day.outputs.DAY_NAME }}"
-            printf "%s\n\n" "${{ steps.check_status.outputs.STATUS_MESSAGE }}"
+          cat > slack_message.txt << 'MESSAGE_END'
+          # 📅 Daily Release Status Report
+          ## 🗓️ ${{ steps.get_day.outputs.DAY_NAME }} | ⏰ Generated at $(date -u '+%H:%M') UTC
+          
+          ---
+          
+          ### 🚦 Automatic Release Status
+          ${{ steps.check_status.outputs.STATUS_MESSAGE }}
+          
+          MESSAGE_END
+          
+          # Add scheduled releases section
+          if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
+            cat >> slack_message.txt << 'MESSAGE_END'
+          ### 🚀 Today's Scheduled Releases
+          
+          ${{ steps.get_releases.outputs.RELEASES }}
+          
+          MESSAGE_END
             
-            if [ "${{ steps.get_releases.outputs.HAS_RELEASES }}" == "true" ]; then
-              printf "## 🚀 Scheduled Releases for Today:\n"
-              printf "%s\n" "${{ steps.get_releases.outputs.RELEASES }}"
-              
-              if [ -n "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" ] && [ "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" != "No pre-releases found for today's scheduled repos" ]; then
-                printf "## 📦 Pre-release Status:\n"
-                printf "%s\n" "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}"
-              fi
+            # Add pre-release section if there are any
+            if [ "${{ steps.check_prereleases.outputs.HAS_PRERELEASES }}" == "true" ]; then
+              cat >> slack_message.txt << 'MESSAGE_END'
+          ### 📦 Pre-releases Ready for Promotion
+          🎯 The following pre-releases are newer than their latest releases and will be promoted:
+          
+          ${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}
+          
+          MESSAGE_END
             else
-              printf "## 📋 Scheduled Releases:\n"
-              printf "%s\n" "${{ steps.get_releases.outputs.RELEASES }}"
+              cat >> slack_message.txt << 'MESSAGE_END'
+          ### 📦 Pre-release Status
+          ℹ️ No new pre-releases ready for promotion today.
+          
+          MESSAGE_END
             fi
             
-            printf "\n---\n"
-            printf "_Generated by [Workflow Run #%s](%s/%s/actions/runs/%s)_" \
-              "${{ github.run_number }}" \
-              "${{ github.server_url }}" \
-              "${{ github.repository }}" \
-              "${{ github.run_id }}"
-          } > slack_message.txt
+            # Add summary stats
+            REPO_COUNT=$(echo "${{ steps.get_releases.outputs.RELEASES }}" | grep -c "| \*\*" || echo "0")
+            PRERELEASE_COUNT=$(echo "${{ steps.check_prereleases.outputs.PRERELEASE_STATUS }}" | grep -c "🆕" || echo "0")
+            
+            {
+              echo "### 📊 Summary"
+              echo "• 📅 **Total scheduled releases:** $REPO_COUNT"
+              echo "• 🆕 **Pre-releases to promote:** $PRERELEASE_COUNT"
+              
+              if [ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ]; then
+                echo "• ✅ **Status:** Ready to release! 🎉"
+              else
+                echo "• ⚠️ **Status:** Releases blocked - manual intervention required"
+              fi
+              echo ""
+            } >> slack_message.txt
+          else
+            cat >> slack_message.txt << 'MESSAGE_END'
+          ### 📋 Release Schedule
+          😴 ${{ steps.get_releases.outputs.RELEASES }}
           
-          # Read the message and save to output
-          echo "SLACK_MESSAGE<<EOF" >> $GITHUB_OUTPUT
-          cat slack_message.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          MESSAGE_END
+          fi
+          
+          # Add footer
+          cat >> slack_message.txt << MESSAGE_END
+          ---
+          _🤖 Generated by [Workflow Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_
+          _💡 To $([ "${{ steps.check_status.outputs.RELEASES_ENABLED }}" == "true" ] && echo "disable" || echo "enable") automatic releases, trigger the appropriate workflow_
+          MESSAGE_END
+          
+          # Save to GitHub output
+          {
+            echo "SLACK_MESSAGE<<EOF"
+            cat slack_message.txt
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
         uses: archive/github-actions-slack@master


### PR DESCRIPTION
Our daily release status messages in Slack are pretty broken right now. This makes it tough to quickly see what's going on with releases.

This fixes the formatting by switching to proper Slack markup, turning those ugly tables into clean bullet points, and adding some nice emojis to make things easier to scan. Also got rid of that annoying workflow link at the bottom that nobody needs.

Now the team will actually get readable daily updates showing whether releases are blocked, what's scheduled for today, and which pre-releases are ready to go - all in a format that doesn't hurt your eyes.

