### PR TITLE
fix(grype): Adds grype to the security scan

### DIFF
--- a/.github/workflows/_test_build_fake_prerelease.yaml
+++ b/.github/workflows/_test_build_fake_prerelease.yaml
@@ -55,7 +55,7 @@ jobs:
       - shell: bash
         run: git tag "$TAG"
       - name: Download artifact from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: windows-packages
       - name: Extract .exe

--- a/.github/workflows/reusable_security.yaml
+++ b/.github/workflows/reusable_security.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   trivy:
     name: Trivy security scan
@@ -59,3 +63,42 @@ jobs:
         if: ${{ github.event.schedule }}  # Upload sarif when running periodically
         with:
           sarif_file: 'trivy-results.sarif'
+          category: trivy
+
+  grype:
+    name: Grype security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Grype vulnerability scanner in repo mode
+        uses: anchore/scan-action@v7
+        if: ${{ ! github.event.schedule }}  # Do not run inline checks when running periodically
+        id: grype-inline
+        with:
+          path: "."
+          fail-build: true
+          severity-cutoff: high
+          only-fixed: true
+          cache-db: true
+          output-format: table
+
+
+      - name: Run Grype vulnerability scanner sarif output
+        uses: anchore/scan-action@v7
+        if: ${{ github.event.schedule }}  # Generate sarif when running periodically
+        id: grype-sarif
+        with:
+          path: "."
+          output-format: sarif
+          output-file: grype-results.sarif
+          only-fixed: true
+          cache-db: true
+
+      - name: Upload Grype scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ github.event.schedule }}  # Upload sarif when running periodically
+        with:
+          sarif_file: 'grype-results.sarif'
+          category: grype

--- a/.github/workflows/reusable_security.yaml
+++ b/.github/workflows/reusable_security.yaml
@@ -15,6 +15,20 @@ on:
         required: false
         type: string
         default: ''
+      binary-path:
+        description: |
+          Path to a pre-built binary (or directory of binaries) to scan with Grype.
+          When set, Grype scans the binary instead of the source directory, ensuring
+          only dependencies actually shipped to customers are reported (test-only
+          dependencies are excluded because they are not linked into the binary).
+          The calling workflow is responsible for building the binary before invoking
+          this workflow.
+          When not set, Grype falls back to scanning the source directory (dir:.),
+          which includes all go.mod dependencies regardless of whether they are
+          test-only.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -72,12 +86,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Generate Grype exclusion config
+        if: ${{ inputs.skip-dirs != '' || inputs.skip-files != '' }}
+        env:
+          SKIP_DIRS: ${{ inputs.skip-dirs }}
+          SKIP_FILES: ${{ inputs.skip-files }}
+        run: |
+          {
+            echo "exclude:"
+            IFS=',' read -ra DIRS <<< "$SKIP_DIRS"
+            for dir in "${DIRS[@]}"; do
+              dir="${dir// /}"
+              [ -n "$dir" ] && echo "  - '**/$dir/**'"
+            done
+            IFS=',' read -ra FILES <<< "$SKIP_FILES"
+            for file in "${FILES[@]}"; do
+              file="${file// /}"
+              [ -n "$file" ] && echo "  - '**/$file'"
+            done
+          } > .grype.yaml
+
       - name: Run Grype vulnerability scanner in repo mode
         uses: anchore/scan-action@v7
         if: ${{ ! github.event.schedule }}  # Do not run inline checks when running periodically
         id: grype-inline
         with:
-          path: "."
+          path: "${{ inputs.binary-path || '.' }}"
+          grype-config: ${{ (inputs.skip-dirs != '' || inputs.skip-files != '') && '.grype.yaml' || '' }}
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -90,7 +125,8 @@ jobs:
         if: ${{ github.event.schedule }}  # Generate sarif when running periodically
         id: grype-sarif
         with:
-          path: "."
+          path: "${{ inputs.binary-path || '.' }}"
+          grype-config: ${{ (inputs.skip-dirs != '' || inputs.skip-files != '') && '.grype.yaml' || '' }}
           output-format: sarif
           output-file: grype-results.sarif
           only-fixed: true


### PR DESCRIPTION
Undoing #171 
The changes includes support to the Grype scans 
- Excluding tools go mod from scans 
- Reports CRITICAL, HIGH vulnerability 