### PR TITLE
fix: add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/build_publish_builder_image.yaml
+++ b/.github/workflows/build_publish_builder_image.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     name: Build and Push Builder Image

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -8,6 +8,9 @@ on:
       - renovate/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   renovate-config-validator:
     name: Renovatebot config validator

--- a/.github/workflows/renovatebot_config_linter.yaml
+++ b/.github/workflows/renovatebot_config_linter.yaml
@@ -2,6 +2,9 @@ name: Test Renovatebot configuration
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   renovate-config-validator:
     name: Renovatebot config validator

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -6,6 +6,10 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolinter:
     uses: ./.github/workflows/reusable_repolinter.yaml

--- a/.github/workflows/reusable_repolinter.yaml
+++ b/.github/workflows/reusable_repolinter.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         default: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.yml
 
+permissions:
+  contents: read
+  issues: write
+
 # NOTE: This workflow will ONLY check the default branch!
 # Currently there is no elegant way to specify the default
 # branch in the event filtering, so branches are instead

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   security:
   # uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v1


### PR DESCRIPTION
CodeQL flagged six workflows with no explicit permissions block (actions/missing-workflow-permissions). Add a top-level permissions block to each, granting only the scopes the workflow needs:

- on_push_pr, renovatebot_config_linter: contents: read
- repolinter, reusable_repolinter: contents: read + issues: write (repolinter-action creates issues)
- security: contents: read + security-events: write (uploads SARIF)
- build_publish_builder_image: contents: read + packages: write (pushes image to ghcr.io)

Fixes [NR-560431](https://new-relic.atlassian.net/browse/NR-560431)

[NR-560431]: https://new-relic.atlassian.net/browse/NR-560431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ